### PR TITLE
docs: Add comprehensive implementation plan and architecture documentation

### DIFF
--- a/docs/adr/0001-workspace-crate-structure.md
+++ b/docs/adr/0001-workspace-crate-structure.md
@@ -1,0 +1,64 @@
+# ADR 0001: Workspace Crate Structure
+
+**Date:** 2026-03-15
+**Status:** Accepted
+**Author:** Tom F.
+
+---
+
+## Context
+
+The A2A protocol has three distinct concerns with different dep trees:
+
+1. **Types** — pure data structures for the protocol; no I/O.
+2. **Client** — sending A2A requests over HTTP; needs async + HTTP stack.
+3. **Server** — receiving and dispatching A2A requests; needs async + HTTP stack.
+
+A single-crate approach forces every user to compile the full dep tree regardless of need. An agent server implementor must not pay for the client dep tree and vice versa.
+
+A2A also has a known future extension (gRPC transport, Phase 8+) that requires `prost` and `tonic` — heavyweight codegen deps that no pure-HTTP user should be forced to include.
+
+## Decision
+
+The workspace is divided into four crates:
+
+```
+a2a-types   (serde only)
+a2a-client  (a2a-types + hyper + tokio)
+a2a-server  (a2a-types + hyper + tokio)
+a2a-sdk     (re-exports all three)
+```
+
+`a2a-client` and `a2a-server` are siblings; neither depends on the other. This mirrors the Go SDK's package separation between `a2aclient` and `a2asrv`.
+
+## Consequences
+
+### Positive
+
+- An agent implementor adds `a2a-server` only; they do not compile client code.
+- An orchestrator adds `a2a-client` only; they do not compile server code.
+- Type-only users (downstream SDKs, protocol validators) add `a2a-types` only.
+- Future `a2a-grpc` crate can depend on `a2a-types` without disturbing existing users.
+- `a2a-sdk` gives quick-start users a single dep.
+
+### Negative
+
+- Four `Cargo.toml` files to maintain.
+- Cross-crate refactors require coordinated version bumps.
+- The umbrella crate `a2a-sdk` must be re-published when any constituent crate changes.
+
+## Alternatives Considered
+
+### Single Crate with Feature Flags
+
+`a2a-rs` with `features = ["client", "server", "grpc"]`. Rejected because:
+- Feature unification in workspaces causes dep pollution across crates.
+- Compile-time savings are smaller than crate-level splits in practice.
+- API surface becomes harder to document cleanly.
+
+### Two Crates (types + sdk)
+
+Merge client and server into one `a2a-sdk`. Rejected because:
+- Forces agent implementors to compile client code they will never use.
+- Forces orchestrators to compile server code they will never use.
+- Asymmetric dep trees (server needs `uuid` for ID gen; client does not in the same way).

--- a/docs/adr/0002-dependency-philosophy.md
+++ b/docs/adr/0002-dependency-philosophy.md
@@ -1,0 +1,112 @@
+# ADR 0002: Dependency Philosophy and Minimal Footprint
+
+**Date:** 2026-03-15
+**Status:** Accepted
+**Author:** Tom F.
+
+---
+
+## Context
+
+Rust SDK quality is inversely correlated with transitive dep count. Each dependency:
+- Adds compile time.
+- Adds supply chain attack surface.
+- Constrains downstream version choices.
+- Can introduce incompatible license terms.
+
+A production-grade A2A SDK must be usable in embedded or resource-constrained environments, in corporate environments with strict dep audit requirements, and without forcing users into specific TLS or logging frameworks.
+
+## Decision
+
+### Mandatory Runtime Dependencies
+
+Only dependencies with no viable in-tree alternative:
+
+| Dep | Rationale |
+|---|---|
+| `serde` + `serde_json` | A2A is a JSON-RPC protocol. There is no reasonable alternative to serde in the Rust ecosystem for correct, zero-copy JSON at this level. |
+| `tokio` (minimal features) | Async I/O is essential; tokio is the de-facto standard. Features pinned to: `rt, net, io-util, sync, time`. Not `full`. |
+| `hyper` 1.x | Lowest-level HTTP library in common Rust use. Brings no cookie jar, no redirect policy, no multipart support. The API is explicit about what it does. |
+| `http-body-util` | Required adapter for hyper 1.x body types. No alternative within hyper 1.x. |
+| `hyper-util` | Connection pooling for the client; client-legacy for compatibility. |
+| `uuid` | Task, Message, Artifact, and Context IDs are UUIDs per spec. Feature: `v4` only (6 source files). |
+
+### Explicitly Excluded (and why)
+
+| Dep | Reason for exclusion |
+|---|---|
+| `reqwest` | 30+ transitive deps; includes native-tls, cookie jar, redirect, multipart — none needed here. |
+| `anyhow` | Erases error types; downstream crates lose the ability to pattern-match on specific errors. We define `A2aError` with typed variants. |
+| `thiserror` | Macro sugar that adds a proc-macro dep. `std::fmt::Display` + `std::error::Error` manual impls are 10 lines and fully explicit. |
+| `tokio-util` | Use `http-body-util` for hyper body adapters; `tokio-util` codec is not needed. |
+| `futures` | We need only `std::future::Future` and `tokio` combinators. The `futures` crate adds 12+ sub-crates. |
+| `openssl-sys` | System dep; builds fail on musl/alpine without extra packages. `rustls` is pure Rust with no system dep. |
+| `log` | Older logging API; superseded by `tracing`. Made optional via feature flag. |
+| `base64` | Used only for `FileWithBytes.bytes` field. Implemented inline (~40 lines) using `std` primitives rather than adding a dep. |
+
+### Feature Flags for Optional Deps
+
+```toml
+[features]
+default = []
+tracing = ["dep:tracing"]
+tls-rustls = ["dep:rustls", "dep:tokio-rustls", "dep:webpki-roots"]
+```
+
+### Version Bounding
+
+All versions use bounded ranges (no open-ended `>=`):
+```toml
+serde      = { version = ">=1.0.200, <2", features = ["derive"] }
+tokio      = { version = ">=1.38, <2",    features = ["rt", "net", "io-util", "sync", "time"] }
+hyper      = { version = ">=1.4, <2",     features = ["client", "server", "http1", "http2"] }
+```
+
+Upper bounds prevent silent adoption of breaking changes between SemVer majors that have historically been incompatible within the Rust ecosystem.
+
+## `deny.toml` Enforcement
+
+```toml
+[licenses]
+allow = ["Apache-2.0", "MIT", "BSD-2-Clause", "BSD-3-Clause", "ISC", "Unicode-DFS-2016"]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "warn"
+deny = [
+    { name = "openssl-sys" },
+    { name = "reqwest" },
+]
+
+[sources]
+unknown-git = "deny"
+unknown-registry = "deny"
+```
+
+## Consequences
+
+### Positive
+
+- Compile time for `a2a-types` is dominated by serde proc-macros only (~8s cold).
+- No system library requirements; cross-compilation to `musl` and `wasm32` is possible.
+- License audit is simple: everything is MIT/Apache-2.0.
+- Downstream crates with strict dep policies can audit a short list.
+
+### Negative
+
+- Base64 encoding must be maintained in-tree (~40 lines).
+- TLS requires a feature flag; users must opt in for HTTPS.
+- No built-in retry logic (users bring their own or use the interceptor API).
+
+## Alternatives Considered
+
+### Use `reqwest` for HTTP
+
+Rejected. `reqwest` is excellent for application code but wrong for SDK infrastructure:
+- Its cookie and redirect handling conflicts with A2A's requirement for precise HTTP control.
+- 30+ transitive deps violate our minimal footprint goal.
+- Cannot serve HTTP (server-side) — requires a separate dep anyway.
+
+### Use `axum` for Server
+
+Rejected. Framework lock-in. Users who have chosen `actix-web`, `warp`, or raw `hyper` would be forced to add `axum` as a dep. The server is implemented directly on `hyper` and exposes a transport-agnostic `RequestHandler` trait that any framework can wrap.

--- a/docs/adr/0003-async-runtime-strategy.md
+++ b/docs/adr/0003-async-runtime-strategy.md
@@ -1,0 +1,81 @@
+# ADR 0003: Async Runtime Strategy
+
+**Date:** 2026-03-15
+**Status:** Accepted
+**Author:** Tom F.
+
+---
+
+## Context
+
+Rust async code is runtime-agnostic at the language level, but practical HTTP libraries are not. `hyper` 1.x uses `tokio` internally for its connection management. Making the SDK runtime-agnostic would require wrapping every I/O call behind an abstraction layer — a significant complexity cost with negligible real-world benefit, since >95% of Rust async production code runs on tokio.
+
+## Decision
+
+**Tokio is the mandatory async runtime.** It is listed as a mandatory dep (not optional, not feature-gated for the I/O crates).
+
+Tokio features are pinned to the minimum needed:
+
+| Crate | Tokio features |
+|---|---|
+| `a2a-types` | none (no async) |
+| `a2a-client` | `rt, net, io-util, sync, time` |
+| `a2a-server` | `rt, net, io-util, sync, time` |
+
+`rt-multi-thread` is **not** forced. Users who run single-threaded runtimes (`#[tokio::main(flavor = "current_thread")]`) are supported without modification.
+
+### async fn in Traits
+
+Rust 1.75 stabilized `async fn` in traits (RPITIT). This SDK targets Rust 1.93+ and uses `async fn` in all trait definitions without boxing:
+
+```rust
+// Preferred — zero overhead, no Pin<Box<dyn Future>>
+pub trait AgentExecutor: Send + Sync + 'static {
+    async fn execute(&self, ctx: &RequestContext, queue: &dyn EventQueueWriter) -> A2aResult<()>;
+    async fn cancel(&self, ctx: &RequestContext, queue: &dyn EventQueueWriter) -> A2aResult<()>;
+}
+```
+
+This requires the trait to be `Send + Sync + 'static` (enforced by bounds) so that futures returned by `async fn` are `Send`, allowing them to be spawned on tokio's multi-thread scheduler.
+
+### No Blocking I/O in Async Contexts
+
+The `tokio::task::spawn_blocking` primitive is used for any CPU-bound work that cannot be expressed as async (e.g., blocking crypto operations, if ever needed). No `std::thread::sleep` in async contexts — use `tokio::time::sleep`.
+
+### `#[tokio::test]` for All Tests
+
+All async tests use the `#[tokio::test]` macro. No manual `tokio::runtime::Runtime::new()` or `block_on` in test code.
+
+## Consequences
+
+### Positive
+
+- No runtime abstraction layer to maintain.
+- `hyper` integration is direct and correct.
+- `async fn` in traits gives clean, readable interfaces with zero runtime cost.
+- All spawned tasks are `Send`, enabling multi-threaded runtimes.
+
+### Negative
+
+- Users on `async-std` or `smol` runtimes cannot use this SDK as-is.
+- `tokio` appears in `a2a-client` and `a2a-server`'s public dep trees.
+
+## Alternatives Considered
+
+### Runtime-Agnostic via `async-trait` Crate
+
+The `async-trait` proc-macro desugars `async fn` in traits to `Pin<Box<dyn Future + Send>>`. Rejected because:
+- Adds an extra dep.
+- Boxes every future, adding allocation overhead.
+- Rust 1.75+ makes this approach obsolete.
+
+### Runtime-Agnostic via `futures` Traits
+
+Abstract over `AsyncRead`/`AsyncWrite` using `futures::io`. Rejected because:
+- `futures` brings 12+ sub-crates.
+- `hyper` and `tokio` use `tokio::io` traits, not `futures::io` — adapter layer required.
+- No meaningful portability gain since `hyper` mandates tokio anyway.
+
+### Use `async-std`
+
+Rejected: `hyper` 1.x does not officially support `async-std`. Community wrappers exist but are not production-hardened.

--- a/docs/adr/0004-transport-abstraction.md
+++ b/docs/adr/0004-transport-abstraction.md
@@ -1,0 +1,122 @@
+# ADR 0004: Transport Abstraction Design
+
+**Date:** 2026-03-15
+**Status:** Accepted
+**Author:** Tom F.
+
+---
+
+## Context
+
+The A2A 0.3.0 specification defines three transport bindings:
+1. **JSON-RPC 2.0** — HTTP POST to a single endpoint; primary binding.
+2. **HTTP+JSON (REST)** — RESTful paths and verbs.
+3. **gRPC** — protobuf, HTTP/2 streaming.
+
+For the client, the `AgentCard` declares a `preferredTransport` and an `additionalInterfaces` list. A complete client implementation must be able to select the best transport for a given agent.
+
+For the server, operators must be able to expose one or more transports without re-implementing protocol logic.
+
+Both sides share the same protocol logic (`RequestHandler`/`A2aClient`). The protocol logic must not be duplicated across transport implementations.
+
+## Decision
+
+### Client-Side Transport Trait
+
+```rust
+pub trait Transport: Send + Sync + 'static {
+    async fn send_request(
+        &self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> ClientResult<serde_json::Value>;
+
+    async fn send_streaming_request(
+        &self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> ClientResult<SseFrameStream>;
+}
+```
+
+`A2aClient` holds a `Box<dyn Transport>` (or concrete generic `A2aClient<T: Transport>`). The client API methods (`send_message`, `get_task`, etc.) are transport-agnostic — they build typed params, call `transport.send_request()`, and deserialize the result.
+
+Two concrete implementations ship in `a2a-client`:
+- `JsonRpcTransport` — HTTP POST to agent's `url` field.
+- `RestTransport` — HTTP verbs to REST paths.
+
+gRPC transport is out of scope for Phase 1 (see ADR 0001).
+
+### Server-Side Transport Adapters
+
+`RequestHandler<E>` is transport-agnostic: it receives typed params and returns typed results. Transport adapters wrap it:
+
+```rust
+// JSON-RPC adapter
+pub struct JsonRpcHandler<E: AgentExecutor> {
+    handler: Arc<RequestHandler<E>>,
+}
+impl<E: AgentExecutor> JsonRpcHandler<E> {
+    // Accepts raw hyper Request, returns hyper Response
+    pub async fn handle(&self, req: Request<Incoming>) -> Response<BoxBody>;
+}
+
+// REST adapter
+pub struct RestHandler<E: AgentExecutor> {
+    handler: Arc<RequestHandler<E>>,
+}
+impl<E: AgentExecutor> RestHandler<E> {
+    pub async fn handle(&self, req: Request<Incoming>) -> Response<BoxBody>;
+}
+```
+
+Users integrate these into their HTTP framework of choice:
+
+```rust
+// Direct hyper integration
+let json_rpc = Arc::new(JsonRpcHandler::new(request_handler));
+let service = service_fn(move |req| {
+    let h = Arc::clone(&json_rpc);
+    async move { h.handle(req).await }
+});
+```
+
+### Transport Selection Logic (Client)
+
+`ClientBuilder` selects transport based on `AgentCard`:
+1. If `AgentCard.preferredTransport == JsonRpc` → use `JsonRpcTransport`.
+2. If `preferredTransport == Rest` → use `RestTransport`.
+3. If user config has `preferred_transports` list → try in order, use first supported.
+4. Default: `JsonRpcTransport` (simplest, most universally supported).
+
+## Consequences
+
+### Positive
+
+- Protocol logic is written once in `RequestHandler` / `A2aClient`; transport adapters are thin.
+- Users can implement custom `Transport` impls (WebSocket, unix socket, in-process) without modifying library code.
+- Adding gRPC transport in Phase 8 requires only a new crate; no changes to existing code.
+- Server adapters work with any HTTP framework (hyper directly, actix, axum, etc.).
+
+### Negative
+
+- `serde_json::Value` as the intermediate format means each request is serialized and deserialized twice (typed → Value → typed). This is a correctness/flexibility tradeoff; benchmarks will quantify the overhead.
+- Custom `Transport` implementations must handle SSE framing themselves for streaming.
+
+## Alternatives Considered
+
+### Generic Transport at Client Level: `A2aClient<T: Transport>`
+
+Use generics instead of `Box<dyn Transport>`. Rejected for the initial release because:
+- Complicates the public API (users must spell out the transport type parameter).
+- Makes `A2aClient` non-object-safe, complicating test doubles.
+- Dynamic dispatch overhead is negligible (one vtable lookup per request, amortized over network RTT).
+
+Revisit in v0.2.0 if benchmarks show meaningful cost.
+
+### Separate Client Structs per Transport
+
+`JsonRpcClient`, `RestClient`. Rejected because:
+- Code duplication for all 11 methods × 2 (or more) transports.
+- Users who switch transports must change their code.
+- Contradicts the protocol abstraction goal.

--- a/docs/adr/0005-sse-streaming-design.md
+++ b/docs/adr/0005-sse-streaming-design.md
@@ -1,0 +1,112 @@
+# ADR 0005: SSE Streaming Design
+
+**Date:** 2026-03-15
+**Status:** Accepted
+**Author:** Tom F.
+
+---
+
+## Context
+
+The A2A `message/stream` and `tasks/resubscribe` methods return Server-Sent Events (SSE) streams. SSE is a plain-text HTTP/1.1 streaming protocol defined in the HTML Living Standard (WHATWG). The A2A spec wraps each event's `data:` field in a `JSONRPCResponse<StreamResponse>`.
+
+Rust does not have a battle-tested, zero-dep SSE server or client library that is hyper 1.x native. Third-party crates (`eventsource-client`, `sse-codec`) either use older hyper versions, carry additional deps, or lack proper backpressure.
+
+## Decision
+
+### In-Tree SSE Implementation
+
+Both client-side SSE parsing and server-side SSE emission are implemented in-tree with zero additional deps. The implementations are ~220 and ~200 lines respectively, within the 500-line limit.
+
+### Client-Side: `sse_parser.rs`
+
+A byte-stream state machine that reads from a `hyper::body::Incoming` byte stream:
+
+```
+State machine:
+  IDLE → accumulating line bytes
+  NEWLINE → process line (data/event/id/retry/comment)
+  DOUBLE_NEWLINE → dispatch accumulated frame
+```
+
+Handles:
+- `data: {...json...}` — accumulated across multiple `data:` lines (concatenated with `\n`).
+- `:` lines — keep-alive comments, silently ignored.
+- `event:` field — optional event type (A2A uses the default empty event type).
+- `retry:` field — reconnection hint, stored but not automatically acted on.
+- Fragmented TCP segments — the parser accumulates bytes without assuming line boundaries align with chunks.
+
+Returns `SseFrame { data: String, event_type: Option<String>, id: Option<String>, retry: Option<u64> }`.
+
+`EventStream` wraps the frame stream and deserializes each `data` field as `JsonRpcResponse<StreamResponse>`.
+
+### Server-Side: `sse.rs`
+
+An `SseResponseBuilder` constructs a `hyper::Response` with:
+- Status: 200
+- `Content-Type: text/event-stream`
+- `Cache-Control: no-cache`
+- `Connection: keep-alive`
+- Chunked transfer encoding (via `http-body-util::StreamBody`)
+
+Each `StreamResponse` event is encoded as:
+```
+data: {"jsonrpc":"2.0","id":"...","result":{...}}\n\n
+```
+
+Keep-alive frames are encoded as:
+```
+: keep-alive\n\n
+```
+
+The server SSE writer holds a `tokio::sync::mpsc::Receiver<SseFrame>` and polls both the receiver and a `tokio::time::interval` for keep-alive ticks. The `EventQueueManager` owns the corresponding `Sender<SseFrame>`.
+
+### Backpressure
+
+The `mpsc` channel between `AgentExecutor` and the SSE writer is bounded (default capacity: 64 events). If the channel is full, `EventQueueWriter::write` returns `A2aError::Internal` with message `"event queue full"`. The executor should handle this by slowing down or yielding. This prevents unbounded memory growth in slow-consumer scenarios.
+
+### Stream Termination
+
+The A2A spec uses `TaskStatusUpdateEvent.final: true` to signal end-of-stream. The server SSE writer inspects each event: when it sees `final: true`, it drains remaining buffered events, writes them, then closes the response body. The client `EventStream` treats the `final: true` event as the last item and returns `None` from `next()` after yielding it.
+
+### Resubscription
+
+`tasks/resubscribe` allows a client to reconnect to an in-progress SSE stream after a disconnect. The `EventQueueManager::get(task_id)` returns the existing queue if the task is still `working` or `input-required`. The new SSE response writer subscribes to the same queue. Events already consumed by the previous subscriber are not replayed (clients must handle potential gaps using `TaskVersion`).
+
+### Error During Streaming
+
+If `AgentExecutor::execute` returns an `A2aError`, the server:
+1. Converts the error to a `TaskStatusUpdateEvent { state: Failed, ... }` with `final: true`.
+2. Writes this terminal event to the queue.
+3. Closes the queue.
+
+The client receives the terminal event, marks the stream as ended, and returns the error from the next `EventStream::next()` call as `ClientResult::Err(ClientError::Protocol(A2aError { code: InternalError, ... }))`.
+
+## Consequences
+
+### Positive
+
+- Zero additional deps for full SSE support.
+- SSE parser handles all real-world edge cases (fragmented TCP, keep-alive, multi-line data).
+- Backpressure prevents OOM in slow-consumer scenarios.
+- Stream termination is deterministic and spec-compliant.
+
+### Negative
+
+- In-tree SSE code must be maintained when the SSE spec changes (rare; SSE is stable).
+- Resubscription does not replay missed events; clients must tolerate gaps.
+- Bounded queue (64 events) may need tuning for high-throughput streaming agents; `RequestHandlerBuilder::with_event_queue_capacity(n)` allows override.
+
+## Alternatives Considered
+
+### `eventsource-client` Crate
+
+Rejected: uses hyper 0.14 (incompatible with hyper 1.x); maintenance status uncertain; would add a transitive dep on the old hyper version.
+
+### `async-sse` Crate
+
+Rejected: last released 2020; depends on `http-types` from the `tide` ecosystem; not hyper 1.x compatible.
+
+### Unbounded Channel
+
+Rejected: an agent that emits events faster than the client can consume them would exhaust server memory. Bounded channel with explicit error on overflow is the correct production behavior.

--- a/docs/implementation/plan.md
+++ b/docs/implementation/plan.md
@@ -1,0 +1,1133 @@
+# a2a-rust: Implementation Plan & Roadmap
+
+**Protocol Version:** A2A 0.3.0
+**Target Rust Version:** 1.93.x (stable)
+**License:** Apache-2.0
+**Status:** Pre-implementation — planning complete
+
+---
+
+## Table of Contents
+
+1. [Goals and Non-Goals](#1-goals-and-non-goals)
+2. [Dependency Philosophy](#2-dependency-philosophy)
+3. [Workspace & Crate Structure](#3-workspace--crate-structure)
+4. [Architecture Overview](#4-architecture-overview)
+5. [Complete File Inventory](#5-complete-file-inventory)
+6. [Implementation Phases](#6-implementation-phases)
+   - [Phase 0 — Project Foundation](#phase-0--project-foundation)
+   - [Phase 1 — Protocol Types (`a2a-types`)](#phase-1--protocol-types-a2a-types)
+   - [Phase 2 — HTTP Client (`a2a-client`)](#phase-2--http-client-a2a-client)
+   - [Phase 3 — Server Framework (`a2a-server`)](#phase-3--server-framework-a2a-server)
+   - [Phase 4 — SSE Streaming](#phase-4--sse-streaming)
+   - [Phase 5 — Push Notifications](#phase-5--push-notifications)
+   - [Phase 6 — Umbrella Crate & Examples](#phase-6--umbrella-crate--examples)
+   - [Phase 7 — Quality & Release Preparation](#phase-7--quality--release-preparation)
+7. [Testing Strategy](#7-testing-strategy)
+8. [Quality Gates](#8-quality-gates)
+9. [Coding Standards](#9-coding-standards)
+10. [Protocol Reference Summary](#10-protocol-reference-summary)
+
+---
+
+## 1. Goals and Non-Goals
+
+### Goals
+
+- **Full spec compliance** — every method, type, error code, and transport variant defined in A2A 0.3.0.
+- **Enterprise-grade** — production-ready error handling, no panics, no `unwrap()` at boundaries, structured logging support.
+- **Minimal footprint** — zero mandatory deps beyond `serde`/`serde_json`; optional features gate all I/O.
+- **Modern Rust idioms** — async/await, `async fn` in traits (stable since 1.75), `impl Trait`, `LazyLock`, Edition 2021.
+- **Transport abstraction** — pluggable HTTP backends; the protocol core carries no HTTP dep.
+- **Strict modularity** — 500-line file cap, single-responsibility per module, thin `mod.rs` files.
+- **Complete test coverage** — four-layer testing strategy; E2E tests are non-negotiable.
+- **Zero `unsafe`** — unless crossing true FFI or raw pointer boundaries, with mandatory `// SAFETY:` comments.
+
+### Non-Goals
+
+- gRPC binding in the initial release (tracked in Phase 8+, separate crate `a2a-grpc`).
+- WebSocket transport (not in the 0.3.0 spec).
+- Built-in persistence (TaskStore and PushConfigStore ship as in-memory defaults only; users plug in their own).
+- Opinionated web framework integration (Axum, Actix adapters are examples, not core).
+
+---
+
+## 2. Dependency Philosophy
+
+Every dependency is a maintenance liability and a supply chain risk. The following rules are enforced by `deny.toml`:
+
+### Mandatory Runtime Dependencies
+
+| Crate | Version | Justification | Features |
+|---|---|---|---|
+| `serde` | `>=1.0.200, <2` | JSON-RPC protocol is JSON-only — unavoidable | `derive` |
+| `serde_json` | `>=1.0.115, <2` | JSON serialization for all wire types | default |
+| `tokio` | `>=1.38, <2` | Async runtime; all I/O is async | `rt,net,io-util,sync,time` |
+| `hyper` | `>=1.4, <2` | Raw HTTP/1.1+2 for client and server | `client,server,http1,http2` |
+| `http-body-util` | `>=0.1, <0.2` | Hyper 1.x body combinator | default |
+| `hyper-util` | `>=0.1.6, <0.2` | Connection pooling, graceful shutdown | `client,client-legacy,http1,http2,tokio` |
+| `uuid` | `>=1.8, <2` | Task/Message/Artifact ID generation | `v4` |
+
+### Optional Dependencies (feature-gated)
+
+| Crate | Feature Flag | Justification |
+|---|---|---|
+| `tracing` | `tracing` | Structured logging; zero cost when disabled |
+| `rustls` | `tls-rustls` | TLS for HTTPS without OpenSSL system dep |
+| `tokio-rustls` | `tls-rustls` | Tokio-integrated TLS |
+| `webpki-roots` | `tls-rustls` | Mozilla root certificates |
+
+### Dev/Test Only
+
+| Crate | Purpose |
+|---|---|
+| `tokio` (full) | Integration test runtime |
+| `proptest` | Property-based testing |
+| `wiremock` | HTTP mock server for client tests |
+| `criterion` | Microbenchmarks |
+
+### Explicitly Excluded
+
+- `reqwest` — too many transitive deps (native-tls, cookie jar, etc.)
+- `axum`/`actix-web` — framework lock-in; users choose their own
+- `anyhow`/`thiserror` — we define our own error types (see `a2a-types/src/error.rs`)
+- `openssl-sys` — prefer `rustls` for zero system deps
+- `log` — prefer `tracing` (feature-gated); no mandatory logging dep
+
+---
+
+## 3. Workspace & Crate Structure
+
+```
+a2a-rust/
+├── Cargo.toml                  # workspace manifest
+├── Cargo.lock
+├── LICENSE                     # Apache-2.0
+├── README.md
+├── LESSONS.md                  # Pitfall catalog (grows during development)
+├── CONTRIBUTING.md
+├── rust-toolchain.toml         # channel = "stable", components = [rustfmt, clippy]
+├── deny.toml                   # cargo-deny: licenses, advisories, duplicates
+├── clippy.toml                 # pedantic + nursery overrides
+│
+├── docs/
+│   ├── implementation/
+│   │   ├── plan.md             # THIS DOCUMENT
+│   │   └── type-mapping.md     # Spec types → Rust types with serde annotations
+│   └── adr/
+│       ├── 0001-workspace-crate-structure.md
+│       ├── 0002-dependency-philosophy.md
+│       ├── 0003-async-runtime-strategy.md
+│       ├── 0004-transport-abstraction.md
+│       └── 0005-sse-streaming-design.md
+│
+├── crates/
+│   ├── a2a-types/              # All protocol types — serde only, no I/O
+│   ├── a2a-client/             # HTTP client (hyper-backed)
+│   ├── a2a-server/             # Server framework (hyper-backed)
+│   └── a2a-sdk/                # Convenience umbrella re-export crate
+│
+└── examples/
+    ├── echo-agent/             # Minimal server implementation
+    ├── client-demo/            # Client usage walkthrough
+    └── streaming-agent/        # SSE streaming demonstration
+```
+
+### Crate Dependency Graph
+
+```
+a2a-types  ←─────────────────────────── (no a2a-* deps)
+     ↑
+a2a-client  (depends on a2a-types)
+     ↑
+a2a-server  (depends on a2a-types)
+     ↑
+a2a-sdk     (re-exports a2a-types + a2a-client + a2a-server)
+```
+
+`a2a-client` and `a2a-server` are **siblings** — neither depends on the other.
+
+### Why Four Crates?
+
+| Crate | Audience | Compile Weight |
+|---|---|---|
+| `a2a-types` | Shared by client, server, and downstream type derivers | Minimal |
+| `a2a-client` | Agent orchestrators, test harnesses | +hyper + tokio |
+| `a2a-server` | Agent implementors | +hyper + tokio |
+| `a2a-sdk` | Quick-start users who want everything | All of the above |
+
+A downstream crate that only implements an agent server does not pay for the client's dep tree, and vice versa.
+
+---
+
+## 4. Architecture Overview
+
+### Protocol Layers
+
+```
+┌─────────────────────────────────────────────┐
+│               User Code                      │
+│  (implements AgentExecutor or uses Client)   │
+└───────────────────┬─────────────────────────┘
+                    │
+┌───────────────────▼─────────────────────────┐
+│            a2a-server / a2a-client           │
+│  RequestHandler | AgentExecutor | Client     │
+│  (protocol logic, dispatch, SSE, push)       │
+└───────────────────┬─────────────────────────┘
+                    │
+┌───────────────────▼─────────────────────────┐
+│            Transport Layer                   │
+│  JSON-RPC dispatcher | REST dispatcher       │
+│  (pure HTTP plumbing, no protocol logic)     │
+└───────────────────┬─────────────────────────┘
+                    │
+┌───────────────────▼─────────────────────────┐
+│               hyper 1.x                      │
+│  (raw HTTP/1.1 + HTTP/2, TLS optional)       │
+└─────────────────────────────────────────────┘
+```
+
+### Server 3-Layer Architecture (mirrors Go SDK)
+
+**Layer 1 — User implements `AgentExecutor`:**
+```rust
+pub trait AgentExecutor: Send + Sync + 'static {
+    async fn execute(
+        &self,
+        ctx: &RequestContext,
+        queue: &dyn EventQueueWriter,
+    ) -> Result<(), A2aError>;
+
+    async fn cancel(
+        &self,
+        ctx: &RequestContext,
+        queue: &dyn EventQueueWriter,
+    ) -> Result<(), A2aError>;
+}
+```
+
+**Layer 2 — Framework provides `RequestHandler`:**
+```rust
+pub struct RequestHandler<E: AgentExecutor> { ... }
+impl<E: AgentExecutor> RequestHandler<E> {
+    pub fn builder(executor: E) -> RequestHandlerBuilder<E> { ... }
+    pub async fn on_send_message(&self, params: MessageSendParams) -> A2aResult<SendMessageResponse>;
+    pub async fn on_send_message_stream(&self, params: MessageSendParams) -> A2aResult<EventStream>;
+    pub async fn on_get_task(&self, params: TaskQueryParams) -> A2aResult<Task>;
+    pub async fn on_list_tasks(&self, params: ListTasksParams) -> A2aResult<TaskListResponse>;
+    pub async fn on_cancel_task(&self, params: TaskIdParams) -> A2aResult<Task>;
+    pub async fn on_resubscribe(&self, params: TaskIdParams) -> A2aResult<EventStream>;
+    // push notification config methods...
+    // agent/authenticatedExtendedCard...
+}
+```
+
+**Layer 3 — Transport adapters wire hyper to `RequestHandler`:**
+```rust
+// JSON-RPC transport (HTTP POST to single endpoint)
+pub struct JsonRpcHandler<E: AgentExecutor> { ... }
+
+// REST transport (RESTful HTTP verbs + paths)
+pub struct RestHandler<E: AgentExecutor> { ... }
+```
+
+### Client Architecture
+
+```rust
+pub struct A2aClient { ... }
+
+impl A2aClient {
+    pub async fn from_card(card: &AgentCard) -> A2aResult<Self>;
+    pub fn builder() -> ClientBuilder;
+
+    pub async fn send_message(&self, params: MessageSendParams) -> A2aResult<SendMessageResponse>;
+    pub async fn stream_message(&self, params: MessageSendParams) -> A2aResult<EventStream>;
+    pub async fn get_task(&self, params: TaskQueryParams) -> A2aResult<Task>;
+    pub async fn list_tasks(&self, params: ListTasksParams) -> A2aResult<TaskListResponse>;
+    pub async fn cancel_task(&self, id: TaskId) -> A2aResult<Task>;
+    pub async fn resubscribe(&self, id: TaskId) -> A2aResult<EventStream>;
+    // push notification config methods...
+}
+```
+
+---
+
+## 5. Complete File Inventory
+
+Every file is listed with its single responsibility and estimated line count. No file exceeds 500 lines.
+
+### `crates/a2a-types/`
+
+```
+Cargo.toml                          [~40 lines]  serde + serde_json only
+src/
+  lib.rs                            [~60 lines]  module declarations + pub use re-exports
+  error.rs                          [~120 lines] A2aError enum, A2aResult<T>, error codes
+  task.rs                           [~180 lines] Task, TaskStatus, TaskState, TaskId, TaskVersion
+  message.rs                        [~200 lines] Message, MessageRole, Part, TextPart, FilePart, DataPart, FileContent
+  artifact.rs                       [~100 lines] Artifact, ArtifactId
+  agent_card.rs                     [~280 lines] AgentCard, AgentCapabilities, AgentSkill, AgentProvider, AgentInterface, TransportProtocol
+  security.rs                       [~220 lines] SecurityScheme variants, OAuthFlows, SecurityRequirements, NamedSecuritySchemes
+  events.rs                         [~150 lines] TaskStatusUpdateEvent, TaskArtifactUpdateEvent, StreamResponse (union)
+  jsonrpc.rs                        [~160 lines] JSONRPCRequest, JSONRPCSuccessResponse, JSONRPCErrorResponse, JSONRPCError, JsonRpcId
+  params.rs                         [~200 lines] MessageSendParams, SendMessageConfiguration, TaskQueryParams, TaskIdParams, ListTasksParams, GetPushConfigParams, DeletePushConfigParams
+  push.rs                           [~130 lines] PushNotificationConfig, PushNotificationAuthInfo, TaskPushNotificationConfig
+  extensions.rs                     [~100 lines] AgentExtension, ExtensionUri, AgentCardSignature
+  responses.rs                      [~120 lines] SendMessageResponse (Task|Message union), TaskListResponse, AuthenticatedExtendedCardResponse
+```
+
+### `crates/a2a-client/`
+
+```
+Cargo.toml                          [~50 lines]  a2a-types + hyper + tokio + uuid
+src/
+  lib.rs                            [~50 lines]  module declarations + pub use re-exports
+  error.rs                          [~100 lines] ClientError, ClientResult<T>; From<A2aError>
+  config.rs                         [~120 lines] ClientConfig (preferred transports, output modes, TLS settings)
+  client.rs                         [~280 lines] A2aClient struct, constructor, all method impls (delegates to transport)
+  builder.rs                        [~180 lines] ClientBuilder with method chaining; validates config
+  discovery.rs                      [~160 lines] resolve_agent_card(); fetch /.well-known/agent-card.json; parse + validate
+  interceptor.rs                    [~100 lines] CallInterceptor trait (before/after); InterceptorChain
+  auth.rs                           [~180 lines] AuthInterceptor, CredentialsStore trait, InMemoryCredentialsStore, SessionId
+  transport/
+    mod.rs                          [~40 lines]  Transport trait definition; re-exports
+    jsonrpc.rs                      [~350 lines] HTTP JSON-RPC transport impl; build request, parse response, error mapping
+    rest.rs                         [~380 lines] HTTP REST transport impl; path building, verb mapping, response parsing
+  methods/
+    mod.rs                          [~30 lines]  re-exports only
+    send_message.rs                 [~120 lines] send_message() + stream_message() client methods
+    tasks.rs                        [~200 lines] get_task(), list_tasks(), cancel_task(), resubscribe()
+    push_config.rs                  [~180 lines] set/get/list/delete push notification config
+    extended_card.rs                [~80 lines]  agent/authenticatedExtendedCard call
+  streaming/
+    mod.rs                          [~30 lines]  re-exports
+    sse_parser.rs                   [~220 lines] raw SSE line parser; frame accumulator; handles keep-alive comments
+    event_stream.rs                 [~200 lines] EventStream type (AsyncIterator); reads SSE frames; deserializes events
+```
+
+### `crates/a2a-server/`
+
+```
+Cargo.toml                          [~55 lines]  a2a-types + hyper + tokio + uuid
+src/
+  lib.rs                            [~60 lines]  module declarations + pub use re-exports
+  error.rs                          [~100 lines] ServerError, ServerResult<T>
+  executor.rs                       [~120 lines] AgentExecutor trait; RequestContext struct
+  handler.rs                        [~350 lines] RequestHandler<E>; all on_* method impls
+  builder.rs                        [~200 lines] RequestHandlerBuilder with fluent API; validates required fields
+  request_context.rs                [~130 lines] RequestContext fields + constructors; RelatedTasks loader
+  call_context.rs                   [~100 lines] CallContext (user, extensions, method name)
+  interceptor.rs                    [~120 lines] CallInterceptor + RequestContextInterceptor traits; InterceptorChain
+  dispatch/
+    mod.rs                          [~35 lines]  re-exports
+    jsonrpc.rs                      [~420 lines] parse JSON-RPC body; route by method name; serialize response; error mapping
+    rest.rs                         [~450 lines] parse REST path + verb; route to handler method; serialize response
+  agent_card/
+    mod.rs                          [~40 lines]  re-exports; CORS header constants
+    static_handler.rs               [~80 lines]  StaticAgentCardHandler; serves a fixed AgentCard
+    dynamic_handler.rs              [~100 lines] DynamicAgentCardHandler; AgentCardProducer trait; calls producer per request
+  streaming/
+    mod.rs                          [~35 lines]  re-exports
+    sse.rs                          [~200 lines] SseResponseBuilder; write SSE frames; keep-alive ticker; chunked encoding
+    event_queue.rs                  [~280 lines] EventQueueWriter trait; EventQueueReader trait; InMemoryEventQueue; EventQueueManager
+  push/
+    mod.rs                          [~35 lines]  re-exports
+    sender.rs                       [~220 lines] PushSender trait; HttpPushSender impl (hyper-backed); retry + timeout
+    config_store.rs                 [~200 lines] PushConfigStore trait; InMemoryPushConfigStore impl
+  store/
+    mod.rs                          [~30 lines]  re-exports
+    task_store.rs                   [~280 lines] TaskStore trait; InMemoryTaskStore impl (DashMap); snapshot + versioning
+```
+
+### `crates/a2a-sdk/`
+
+```
+Cargo.toml                          [~40 lines]  re-exports all workspace crates
+src/
+  lib.rs                            [~80 lines]  #![doc = "..."] + pub use a2a_types::*; pub use a2a_client::*; pub use a2a_server::*
+```
+
+### `examples/`
+
+```
+echo-agent/
+  Cargo.toml                        [~20 lines]
+  src/main.rs                       [~180 lines] minimal echo agent: returns input as text artifact
+
+client-demo/
+  Cargo.toml                        [~20 lines]
+  src/main.rs                       [~200 lines] discover card, send message, poll task, print result
+
+streaming-agent/
+  Cargo.toml                        [~20 lines]
+  src/main.rs                       [~250 lines] streaming agent + streaming client; shows SSE round-trip
+```
+
+---
+
+## 6. Implementation Phases
+
+### Phase 0 — Project Foundation
+
+**Deliverables:** Compilable workspace, CI passing green, all tooling configured.
+
+| Task | File(s) | Notes |
+|---|---|---|
+| Workspace `Cargo.toml` | `Cargo.toml` | `[workspace]` with members array; `[profile.release]` with `panic="abort"`, `lto=true`, `opt-level=3`, `codegen-units=1`, `strip=true` |
+| Rust toolchain pin | `rust-toolchain.toml` | `channel = "stable"`, components = `["rustfmt", "clippy"]` |
+| `.gitignore` | `.gitignore` | `/target`, `Cargo.lock` (for libs), `.env` |
+| `deny.toml` | `deny.toml` | Apache-2.0 license list; advisory DB; no git sources; bounded versions |
+| `clippy.toml` | `clippy.toml` | Deny: `clippy::all`, `clippy::pedantic`, `clippy::nursery`; allow: `module_name_repetitions` |
+| CI pipeline | `.github/workflows/ci.yml` | Steps: `fmt --check`, `clippy -D warnings`, `test --all-targets`, `doc --no-deps`, `cargo-deny` |
+| README skeleton | `README.md` | Project overview, quick-start placeholder, status badge |
+| LESSONS skeleton | `LESSONS.md` | Headers for pitfall categories; fill as dev proceeds |
+| Empty crate stubs | Each `crates/*/Cargo.toml` + `src/lib.rs` | Compile-clean empty crates before any implementation |
+
+**Validation:** `cargo build --workspace` exits 0. `cargo test --workspace` exits 0 (no tests yet). CI runs green.
+
+---
+
+### Phase 1 — Protocol Types (`a2a-types`)
+
+**Deliverables:** Complete, serialization-correct Rust types for every A2A 0.3.0 schema.
+
+**Order of implementation (dependency-driven):**
+
+#### 1a. `error.rs` — Error types first (everything depends on these)
+
+```rust
+// All A2A protocol error codes as typed variants
+pub enum ErrorCode {
+    // JSON-RPC standard
+    ParseError       = -32700,
+    InvalidRequest   = -32600,
+    MethodNotFound   = -32601,
+    InvalidParams    = -32602,
+    InternalError    = -32603,
+    // A2A-specific (-32000 to -32099)
+    TaskNotFound                    = -32001,
+    TaskNotCancelable               = -32002,
+    PushNotificationNotSupported    = -32003,
+    UnsupportedOperation            = -32004,
+    ContentTypeNotSupported         = -32005,
+    VersionNotSupported             = -32006,
+    ExtensionSupportRequired        = -32007,
+    InvalidMessage                  = -32008,
+    AuthenticationFailed            = -32009,
+    AuthorizationFailed             = -32010,
+    UnsupportedMode                 = -32011,
+}
+
+pub struct A2aError {
+    pub code: ErrorCode,
+    pub message: String,
+    pub data: Option<serde_json::Value>,
+}
+
+pub type A2aResult<T> = Result<T, A2aError>;
+```
+
+`A2aError` implements: `std::error::Error`, `Display`, `Debug`, `Clone`.
+Constructor methods: `A2aError::task_not_found(id)`, `A2aError::internal(msg)`, etc.
+
+#### 1b. `jsonrpc.rs` — JSON-RPC envelope types
+
+```rust
+pub type JsonRpcId = Option<serde_json::Value>; // string | number | null
+
+pub struct JsonRpcRequest {
+    pub jsonrpc: JsonRpcVersion,   // always "2.0"
+    pub id: JsonRpcId,
+    pub method: String,
+    pub params: Option<serde_json::Value>,
+}
+
+#[serde(untagged)]
+pub enum JsonRpcResponse<T> {
+    Success(JsonRpcSuccessResponse<T>),
+    Error(JsonRpcErrorResponse),
+}
+
+pub struct JsonRpcSuccessResponse<T> {
+    pub jsonrpc: JsonRpcVersion,
+    pub id: JsonRpcId,
+    pub result: T,
+}
+
+pub struct JsonRpcErrorResponse {
+    pub jsonrpc: JsonRpcVersion,
+    pub id: JsonRpcId,
+    pub error: JsonRpcError,
+}
+
+pub struct JsonRpcError {
+    pub code: i64,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+```
+
+#### 1c. `task.rs` — Task, TaskStatus, TaskState
+
+```rust
+// Newtype for compile-time ID distinctness
+pub struct TaskId(String);
+pub struct TaskVersion(u64);
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TaskState {
+    Submitted,
+    Working,
+    InputRequired,
+    AuthRequired,
+    Completed,
+    Failed,
+    Canceled,
+    Rejected,
+    Unknown,
+}
+
+impl TaskState {
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Completed | Self::Failed | Self::Canceled | Self::Rejected)
+    }
+}
+
+pub struct Task {
+    pub id: TaskId,
+    pub context_id: String,
+    pub status: TaskStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub history: Option<Vec<Message>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifacts: Option<Vec<Artifact>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+    pub kind: TaskKind, // always "task"
+}
+```
+
+#### 1d. `message.rs` — Message, Part variants
+
+Serde discriminated union using `#[serde(tag = "kind", rename_all = "lowercase")]`:
+
+```rust
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum Part {
+    Text(TextPart),
+    File(FilePart),
+    Data(DataPart),
+}
+
+pub struct TextPart {
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+pub struct FilePart {
+    pub file: FileContent,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+// Untagged: deserializes as Bytes if `bytes` key present, Uri if `uri` key present
+#[serde(untagged)]
+pub enum FileContent {
+    Bytes(FileWithBytes),
+    Uri(FileWithUri),
+}
+```
+
+#### 1e. `artifact.rs`, `agent_card.rs`, `security.rs`, `events.rs`, `params.rs`, `push.rs`, `extensions.rs`, `responses.rs`
+
+Each implements the corresponding spec types (see `docs/implementation/type-mapping.md` for full field-by-field mapping).
+
+**Key serde patterns used:**
+- `#[serde(rename_all = "camelCase")]` — all structs (spec uses camelCase)
+- `#[serde(skip_serializing_if = "Option::is_none")]` — all optional fields
+- `#[serde(tag = "kind")]` — discriminated unions (Part, StreamResponse)
+- `#[serde(untagged)]` — ambiguous unions (FileContent, JsonRpcResponse, SendMessageResponse)
+- `#[serde(rename = "...")]` — where Rust field name cannot match spec name
+
+**Validation:** `cargo test -p a2a-types` passes. Round-trip JSON tests for all types. Corpus of canonical JSON samples from the spec tested for exact deserialization.
+
+---
+
+### Phase 2 — HTTP Client (`a2a-client`)
+
+**Deliverables:** Working client that can communicate with any A2A-compliant agent over JSON-RPC.
+
+**Order of implementation:**
+
+#### 2a. `error.rs` + `config.rs`
+
+```rust
+pub enum ClientError {
+    Http(hyper::Error),
+    Serialization(serde_json::Error),
+    Protocol(A2aError),
+    Transport(String),
+    InvalidEndpoint(String),
+    AuthRequired { task_id: TaskId },
+}
+pub type ClientResult<T> = Result<T, ClientError>;
+
+pub struct ClientConfig {
+    pub preferred_transports: Vec<TransportProtocol>,
+    pub accepted_output_modes: Vec<String>,
+    pub history_length: Option<u32>,
+    pub return_immediately: bool,
+    pub request_timeout: Duration,
+    pub tls: TlsConfig,
+}
+```
+
+#### 2b. `transport/mod.rs` — Transport trait
+
+```rust
+pub trait Transport: Send + Sync + 'static {
+    async fn send_request(
+        &self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> ClientResult<serde_json::Value>;
+
+    async fn send_streaming_request(
+        &self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> ClientResult<Box<dyn EventStreamSource>>;
+}
+```
+
+#### 2c. `transport/jsonrpc.rs` — JSON-RPC over HTTP
+
+- Build `JsonRpcRequest` with generated ID
+- POST to agent's `url` (from AgentCard)
+- Parse `JsonRpcResponse<serde_json::Value>`
+- Map `JsonRpcError` → `ClientError::Protocol(A2aError)`
+- Streaming: request with `Accept: text/event-stream`, return SSE reader
+
+#### 2d. `streaming/sse_parser.rs` + `streaming/event_stream.rs`
+
+SSE parser is a state machine operating on raw bytes:
+- Accumulates lines into frames
+- Parses `data:`, `event:`, `id:`, `retry:` fields
+- Handles `:` keep-alive comments
+- Returns `SseFrame { event_type, data, id, retry }`
+
+`EventStream` wraps the SSE parser, deserializes `StreamResponse` from each data field:
+```rust
+pub struct EventStream {
+    inner: SseFrameStream,
+}
+
+impl EventStream {
+    pub async fn next(&mut self) -> Option<ClientResult<StreamResponse>>;
+}
+```
+
+#### 2e. `discovery.rs`
+
+```rust
+pub async fn resolve_agent_card(base_url: &str) -> ClientResult<AgentCard>;
+pub async fn resolve_agent_card_with_path(url: &str, path: &str) -> ClientResult<AgentCard>;
+```
+
+Fetches `/.well-known/agent-card.json`, deserializes `AgentCard`, validates `protocolVersion`.
+
+#### 2f. `interceptor.rs` + `auth.rs`
+
+```rust
+pub trait CallInterceptor: Send + Sync + 'static {
+    async fn before(&self, req: &mut ClientRequest) -> ClientResult<()>;
+    async fn after(&self, resp: &ClientResponse) -> ClientResult<()>;
+}
+
+pub struct AuthInterceptor { ... }
+impl CallInterceptor for AuthInterceptor { ... }
+
+pub trait CredentialsStore: Send + Sync + 'static {
+    fn get(&self, session: &SessionId, scheme: &str) -> Option<String>;
+    fn set(&self, session: SessionId, scheme: &str, credential: String);
+    fn remove(&self, session: &SessionId, scheme: &str);
+}
+pub struct InMemoryCredentialsStore(RwLock<HashMap<SessionId, HashMap<String, String>>>);
+```
+
+#### 2g. `builder.rs` + `client.rs`
+
+`ClientBuilder` validates: at least one transport protocol, valid base URL, no conflicting TLS options.
+
+`A2aClient` holds a `Transport` impl + `InterceptorChain` + `ClientConfig`. Each method:
+1. Builds `MessageSendParams` / `TaskQueryParams` etc.
+2. Runs `interceptor.before()`
+3. Calls `transport.send_request()` or `transport.send_streaming_request()`
+4. Deserializes result
+5. Runs `interceptor.after()`
+6. Returns typed result
+
+#### 2h. `methods/` — All client methods
+
+Each file implements 1–3 closely related RPC calls:
+
+| File | Methods |
+|---|---|
+| `send_message.rs` | `send_message()`, `stream_message()` |
+| `tasks.rs` | `get_task()`, `list_tasks()`, `cancel_task()`, `resubscribe()` |
+| `push_config.rs` | `set_push_config()`, `get_push_config()`, `list_push_configs()`, `delete_push_config()` |
+| `extended_card.rs` | `get_authenticated_extended_card()` |
+
+**Validation:** `cargo test -p a2a-client` with `wiremock` mocking. All 11 RPC methods exercised. Auth flow tested. SSE streaming tested with mock SSE server.
+
+---
+
+### Phase 3 — Server Framework (`a2a-server`)
+
+**Deliverables:** A working `AgentExecutor`-based server that can be driven by any hyper HTTP server.
+
+**Order of implementation:**
+
+#### 3a. `error.rs` + `executor.rs`
+
+```rust
+pub trait AgentExecutor: Send + Sync + 'static {
+    async fn execute(
+        &self,
+        ctx: &RequestContext,
+        queue: &dyn EventQueueWriter,
+    ) -> A2aResult<()>;
+
+    async fn cancel(
+        &self,
+        ctx: &RequestContext,
+        queue: &dyn EventQueueWriter,
+    ) -> A2aResult<()>;
+}
+```
+
+#### 3b. `request_context.rs`
+
+```rust
+pub struct RequestContext {
+    pub message: Message,
+    pub task_id: TaskId,
+    pub context_id: String,
+    pub stored_task: Option<Task>,
+    pub metadata: Option<serde_json::Value>,
+}
+```
+
+Constructed by `RequestHandler` before calling `AgentExecutor::execute`. The `stored_task` field carries the previous task snapshot for continuation requests.
+
+#### 3c. `store/task_store.rs`
+
+```rust
+pub trait TaskStore: Send + Sync + 'static {
+    async fn save(&self, task: Task) -> A2aResult<()>;
+    async fn get(&self, id: &TaskId) -> A2aResult<Option<Task>>;
+    async fn list(&self, params: &ListTasksParams) -> A2aResult<TaskListResponse>;
+    async fn delete(&self, id: &TaskId) -> A2aResult<()>;
+}
+
+// Default impl; no external dep; suitable for single-process deployments
+pub struct InMemoryTaskStore {
+    tasks: RwLock<HashMap<TaskId, Task>>,
+}
+```
+
+#### 3d. `streaming/event_queue.rs`
+
+```rust
+pub trait EventQueueWriter: Send + Sync {
+    async fn write(&self, event: StreamResponse) -> A2aResult<()>;
+    async fn close(&self) -> A2aResult<()>;
+}
+
+pub trait EventQueueReader: Send {
+    async fn read(&mut self) -> Option<A2aResult<StreamResponse>>;
+}
+
+// Backed by tokio::sync::mpsc channel
+pub struct InMemoryEventQueue { ... }
+```
+
+#### 3e. `handler.rs` + `builder.rs`
+
+`RequestHandlerBuilder` fluent API:
+```rust
+RequestHandlerBuilder::new(executor)
+    .with_task_store(custom_store)
+    .with_push_sender(http_push_sender)
+    .with_push_config_store(custom_store)
+    .with_interceptor(logging_interceptor)
+    .with_agent_card(card)
+    .build()  // → RequestHandler<E>
+```
+
+`RequestHandler::on_send_message` flow:
+1. Generate `TaskId` (uuid v4), `ContextId` (uuid v4 if not provided)
+2. Create initial `Task { state: Submitted }`
+3. Save to `TaskStore`
+4. Create `InMemoryEventQueue`
+5. Spawn `tokio::task` → calls `executor.execute(ctx, &queue)`
+6. If `return_immediately=true`: return `Task { state: Submitted }`
+7. Else: poll queue for first terminal event, return final `Task`
+
+#### 3f. `dispatch/jsonrpc.rs` + `dispatch/rest.rs`
+
+JSON-RPC dispatcher:
+- Parse `JsonRpcRequest` from HTTP body bytes
+- Match `method` string to handler method
+- Call appropriate `RequestHandler` method
+- Serialize response as `JsonRpcResponse<T>`
+- Streaming: return SSE response for `message/stream` and `tasks/resubscribe`
+
+REST dispatcher:
+- Parse HTTP method + path pattern
+- Extract path parameters (`{taskId}`, etc.)
+- Call appropriate `RequestHandler` method
+- Return JSON response body
+
+Both dispatchers map `A2aError` → `JsonRpcErrorResponse` with correct error codes.
+
+#### 3g. `agent_card/`
+
+```rust
+// Static: card provided at construction time
+pub struct StaticAgentCardHandler { card_json: Bytes }
+
+// Dynamic: card generated per-request
+pub trait AgentCardProducer: Send + Sync + 'static {
+    async fn produce(&self, req: &CardRequest) -> A2aResult<AgentCard>;
+}
+pub struct DynamicAgentCardHandler<P: AgentCardProducer> { producer: P }
+```
+
+Both handlers:
+- Respond to `GET /.well-known/agent-card.json`
+- Set `Content-Type: application/json`
+- Set CORS header `Access-Control-Allow-Origin: *`
+
+#### 3h. `interceptor.rs` + `call_context.rs`
+
+Server-side interceptors run before/after each RPC call, with access to `CallContext` (caller identity, activated extensions, method name).
+
+**Validation:** Integration tests spin up a real hyper server, send JSON-RPC requests, verify responses. `AgentExecutor` implemented as a test double. All 11 methods tested via JSON-RPC and REST dispatchers.
+
+---
+
+### Phase 4 — SSE Streaming
+
+**Deliverables:** Fully functional bidirectional SSE: client consumes events, server produces them.
+
+This phase integrates streaming support added in stubs during Phases 2 and 3.
+
+| Task | Location | Notes |
+|---|---|---|
+| Server SSE writer | `a2a-server/src/streaming/sse.rs` | Chunked transfer; keep-alive `:` comments; `final: true` detection closes stream |
+| Client SSE parser | `a2a-client/src/streaming/sse_parser.rs` | Handles fragmented chunks; reconnect hint via `retry:` field |
+| `message/stream` end-to-end | tests | Client calls `stream_message()`, server emits `TaskStatusUpdateEvent` series, client receives all |
+| `tasks/resubscribe` | both | Client reconnects after disconnect; server replays pending events |
+| EventQueueManager | `a2a-server/src/streaming/event_queue.rs` | `get_or_create(task_id)` + `destroy(task_id)` lifecycle |
+
+**Keep-alive design:** Server sends `: keep-alive\n\n` every 30s (configurable). Client's SSE parser ignores comment lines per spec.
+
+**Backpressure:** `InMemoryEventQueue` uses bounded `tokio::sync::mpsc` channel (default: 64 events). If the queue fills, `EventQueueWriter::write` returns `A2aError::Internal` and the executor is expected to yield.
+
+---
+
+### Phase 5 — Push Notifications
+
+**Deliverables:** Agent can deliver push notifications to client-registered webhooks.
+
+| Task | Location | Notes |
+|---|---|---|
+| `PushConfigStore` trait | `a2a-server/src/push/config_store.rs` | CRUD for `TaskPushNotificationConfig`; keyed by `(TaskId, config_id)` |
+| `InMemoryPushConfigStore` | same file | `RwLock<HashMap<(TaskId, String), PushNotificationConfig>>` |
+| `PushSender` trait | `a2a-server/src/push/sender.rs` | `async fn send(&self, url: &str, event: &StreamResponse, config: &PushNotificationConfig)` |
+| `HttpPushSender` | same file | hyper POST with `Content-Type: application/json`; 30s timeout; honor auth config; optional `A2A-Notification-Token` header |
+| Server integration | `handler.rs` | After each `EventQueueWriter::write`, if push configs exist for `task_id`, call `PushSender::send` |
+| Push config RPC methods | `handler.rs` | `on_set_push_config`, `on_get_push_config`, `on_list_push_configs`, `on_delete_push_config` |
+
+**Security:** `HttpPushSender` inspects `PushNotificationAuthInfo.schemes`:
+- `"bearer"` → `Authorization: Bearer {credentials}`
+- `"basic"` → `Authorization: Basic {base64(credentials)}`
+- Token verification header sent when `PushNotificationConfig.token` is set
+
+---
+
+### Phase 6 — Umbrella Crate & Examples
+
+**Deliverables:** `a2a-sdk` re-export crate; three working examples.
+
+#### `crates/a2a-sdk/src/lib.rs`
+
+```rust
+//! # a2a-sdk
+//!
+//! All-in-one re-export of `a2a-types`, `a2a-client`, and `a2a-server`.
+//! For lower compile times, depend on individual crates directly.
+
+pub use a2a_types::*;
+pub use a2a_client::{A2aClient, ClientBuilder, ClientConfig, ClientError};
+pub use a2a_server::{AgentExecutor, RequestHandler, RequestHandlerBuilder, ServerError};
+```
+
+#### `examples/echo-agent/src/main.rs`
+
+Minimal server that echoes each message as a text artifact. Demonstrates:
+- `AgentExecutor` implementation
+- `RequestHandlerBuilder` construction
+- Starting a hyper server
+- Serving the AgentCard at `/.well-known/agent-card.json`
+
+#### `examples/client-demo/src/main.rs`
+
+Client that:
+1. Discovers the echo agent's card
+2. Sends a message
+3. Polls until task is terminal
+4. Prints the artifact text
+
+#### `examples/streaming-agent/src/main.rs`
+
+Agent that emits multiple `TaskStatusUpdateEvent` and `TaskArtifactUpdateEvent` during processing. Client connects with `stream_message()` and prints each event as it arrives.
+
+---
+
+### Phase 7 — Quality & Release Preparation
+
+**Deliverables:** All quality gates passing, documentation complete, crates publishable.
+
+| Task | Notes |
+|---|---|
+| Property-based tests | `proptest` for `TaskState` transitions, `Part` round-trip, ID generation uniqueness |
+| Corpus-based JSON tests | Deserialize every sample from official spec; verify round-trip |
+| E2E integration tests | Echo agent + client test in the same process; streaming test; push notification test with mock webhook |
+| Benchmark suite | `criterion`: JSON serialization throughput; SSE parse throughput; server handler throughput |
+| `cargo doc --no-deps` | Zero warnings; all public items documented; examples compile |
+| `LESSONS.md` | Document every non-obvious pitfall discovered during implementation |
+| ADR finalization | Each ADR updated with implementation outcomes |
+| `CONTRIBUTING.md` | Testing guide, coding standards, PR checklist |
+| Publish dry-run | `cargo publish --dry-run -p a2a-types`, etc. — verify no missing files |
+| Version alignment | All crates at `0.1.0`; workspace `[package.version]` |
+
+---
+
+## 7. Testing Strategy
+
+### Four Layers (non-negotiable)
+
+| Layer | Tool | Location | Purpose |
+|---|---|---|---|
+| **Unit** | `#[test]` in-source | Each `src/*.rs` file | Pure logic: serde round-trips, state machine transitions, error construction, ID uniqueness |
+| **Property-based** | `proptest` | `src/*.rs` | Invariants: serialization idempotence, terminal state irreversibility, error code stability |
+| **Integration** | `#[tokio::test]` in `tests/` | Each crate's `tests/` dir | Module boundaries: client ↔ mock server, server handler ↔ mock executor |
+| **E2E** | `#[tokio::test]` | `tests/e2e/` | Full round-trip: real client + real server in-process; all transports; streaming; push |
+
+### Test Naming Convention
+
+`{component}_{scenario}_{expected_outcome}`
+
+Examples:
+- `task_state_completed_is_terminal`
+- `text_part_roundtrip_preserves_metadata`
+- `client_send_message_returns_task_on_success`
+- `server_jsonrpc_unknown_method_returns_method_not_found`
+- `sse_parser_keep_alive_comment_is_ignored`
+- `push_sender_bearer_auth_sets_authorization_header`
+
+### Test Organization
+
+Each source file's tests live in its own `#[cfg(test)]` block. Section banners:
+```rust
+// ---------------------------------------------------------------------------
+// serialization tests
+// ---------------------------------------------------------------------------
+```
+
+Integration and E2E tests live in `crates/{crate}/tests/`.
+
+### Non-Negotiable Rules
+
+1. `cargo test --workspace` must pass before any commit to `main`.
+2. E2E tests MUST be written for every transport path (JSON-RPC + REST), streaming, push notifications.
+3. No test may use `unwrap()` without a comment explaining why it cannot fail.
+4. All async tests use `#[tokio::test]` (not `tokio::block_on` in non-async tests).
+
+---
+
+## 8. Quality Gates
+
+All gates must pass before tagging a release. CI enforces all of them.
+
+```bash
+# Formatting (zero diffs allowed)
+cargo fmt --all -- --check
+
+# Linting (zero warnings allowed)
+cargo clippy --workspace --all-targets -- -D warnings
+
+# Tests (all must pass)
+cargo test --workspace --all-targets
+
+# Documentation (zero warnings)
+cargo doc --workspace --no-deps
+
+# MSRV check (Rust 1.93.x)
+rustup run 1.93 cargo check --workspace
+
+# Supply chain (license + advisory + duplicate check)
+cargo deny check
+
+# Publish dry-run
+cargo publish --dry-run -p a2a-types
+cargo publish --dry-run -p a2a-client
+cargo publish --dry-run -p a2a-server
+cargo publish --dry-run -p a2a-sdk
+```
+
+### Release Profile Requirements
+
+```toml
+[profile.release]
+panic        = "abort"
+lto          = true
+opt-level    = 3
+codegen-units = 1
+strip        = true
+```
+
+---
+
+## 9. Coding Standards
+
+Derived from `quack-rs` and applied to this project.
+
+### File-Level
+
+- **SPDX header on every file:**
+  ```
+  // SPDX-License-Identifier: Apache-2.0
+  // Copyright 2026 Tom F.
+  ```
+- **500-line maximum.** When a file approaches 400 lines, extract a submodule.
+- **Thin `mod.rs` files** (35–70 lines): module declarations + `pub use` re-exports only. No logic.
+
+### Error Handling
+
+- `unwrap()` and `expect()` are **forbidden** in library code.
+- `unwrap()` in tests requires a comment: `// SAFETY: test data is hardcoded valid`.
+- `?` operator is the standard propagation mechanism.
+- `panic!()` is forbidden except in `unreachable!()` for provably exhaustive matches.
+
+### Async
+
+- `async fn` in traits (stable Rust 1.75+) — no `Pin<Box<dyn Future>>` boxing.
+- All I/O-bound functions are async. No `std::thread::sleep` or blocking calls in async context.
+- `tokio::task::spawn_blocking` for CPU-bound work that cannot be made async.
+
+### Unsafe
+
+- `unsafe` blocks are **forbidden** unless crossing true FFI or `unsafe` hyper internals.
+- Every `unsafe` block requires a `// SAFETY:` comment explaining the upheld invariants.
+- `#![deny(unsafe_op_in_unsafe_fn)]` in every crate.
+
+### Documentation
+
+- `#![warn(missing_docs)]` in every crate.
+- Module-level docs: purpose → key types → usage example.
+- Public struct/enum docs: what it represents, which spec section defines it.
+- Cross-references: `[TypeName]`, `[method_name()]`.
+
+### Imports
+
+- Group: `std` → external crates → `crate` / `super`.
+- No wildcard imports except in `prelude` modules and test `use super::*`.
+
+---
+
+## 10. Protocol Reference Summary
+
+A condensed quick-reference for implementation use.
+
+### All RPC Methods
+
+| Method | Transport | Params | Returns |
+|---|---|---|---|
+| `message/send` | JSON-RPC POST | `MessageSendParams` | `Task \| Message` |
+| `message/stream` | JSON-RPC POST → SSE | `MessageSendParams` | `EventStream` |
+| `tasks/get` | JSON-RPC POST | `TaskQueryParams` | `Task` |
+| `tasks/list` | JSON-RPC POST | `ListTasksParams` | `TaskListResponse` |
+| `tasks/cancel` | JSON-RPC POST | `TaskIdParams` | `Task` |
+| `tasks/resubscribe` | JSON-RPC POST → SSE | `TaskIdParams` | `EventStream` |
+| `tasks/pushNotificationConfig/set` | JSON-RPC POST | `TaskPushNotificationConfig` | `TaskPushNotificationConfig` |
+| `tasks/pushNotificationConfig/get` | JSON-RPC POST | `GetPushConfigParams` | `TaskPushNotificationConfig` |
+| `tasks/pushNotificationConfig/list` | JSON-RPC POST | `TaskIdParams` | `Vec<TaskPushNotificationConfig>` |
+| `tasks/pushNotificationConfig/delete` | JSON-RPC POST | `DeletePushConfigParams` | `null` |
+| `agent/authenticatedExtendedCard` | JSON-RPC POST | `AuthenticatedExtendedCardParams` | `AuthenticatedExtendedCardResponse` |
+
+### SSE Event Types
+
+| `kind` value | Rust type | When emitted |
+|---|---|---|
+| `"task"` | `Task` | When `message/send` returns a full task immediately |
+| `"message"` | `Message` | When agent response is a single message, not a task |
+| `"status-update"` | `TaskStatusUpdateEvent` | On every task state transition during streaming |
+| `"artifact-update"` | `TaskArtifactUpdateEvent` | When an artifact is ready or appended |
+
+### Terminal Task States
+
+`completed`, `failed`, `canceled`, `rejected` — no further state transitions possible.
+
+### Error Code Quick-Reference
+
+| Code | Name | When to use |
+|---|---|---|
+| -32700 | ParseError | Malformed JSON body |
+| -32600 | InvalidRequest | Missing `jsonrpc`/`method`/`id` fields |
+| -32601 | MethodNotFound | Unknown method name |
+| -32602 | InvalidParams | Params don't match expected schema |
+| -32603 | InternalError | Unexpected server error |
+| -32001 | TaskNotFound | `tasks/get` or `tasks/cancel` with unknown ID |
+| -32002 | TaskNotCancelable | Cancel requested for terminal task |
+| -32003 | PushNotificationNotSupported | Client requests push; server `capabilities.pushNotifications: false` |
+| -32004 | UnsupportedOperation | Method exists but not implemented by this agent |
+| -32005 | ContentTypeNotSupported | Requested MIME type not in `defaultOutputModes` |
+| -32006 | VersionNotSupported | Client/server `A2A-Version` header mismatch |
+| -32007 | ExtensionSupportRequired | `AgentExtension.required: true` and client lacks it |
+| -32008 | InvalidMessage | Message structure violates protocol constraints |
+| -32009 | AuthenticationFailed | Credentials missing or invalid |
+| -32010 | AuthorizationFailed | Credentials valid but insufficient permissions |
+| -32011 | UnsupportedMode | Requested transport/streaming mode unsupported |
+
+### AgentCard Well-Known URI
+
+```
+GET https://{host}/.well-known/agent-card.json
+Response: application/json
+CORS: Access-Control-Allow-Origin: *
+```
+
+### HTTP Headers
+
+| Header | Direction | Purpose |
+|---|---|---|
+| `A2A-Version` | Both | Protocol version negotiation |
+| `A2A-Extensions` | Both | Comma-separated declared extension URIs |
+| `Authorization` | Client→Server | Bearer/Basic auth |
+| `A2A-Notification-Token` | Server→Client (push) | Shared secret for webhook verification |
+| `Content-Type: application/json` | Both | Standard JSON-RPC |
+| `Content-Type: text/event-stream` | Server→Client | SSE streaming response |
+| `Cache-Control: no-cache` | Server→Client (SSE) | Prevent SSE caching |
+
+---
+
+*Document version: 1.0 — initial plan*
+*Last updated: 2026-03-15*
+*Author: Tom F.*

--- a/docs/implementation/type-mapping.md
+++ b/docs/implementation/type-mapping.md
@@ -1,0 +1,603 @@
+# A2A Protocol → Rust Type Mapping
+
+Complete field-by-field mapping from A2A 0.3.0 JSON schema to Rust types.
+All structs use `#[serde(rename_all = "camelCase")]` unless noted.
+All `Option<T>` fields use `#[serde(skip_serializing_if = "Option::is_none")]`.
+
+---
+
+## Primitive / Alias Types
+
+| Spec type | Rust type | Notes |
+|---|---|---|
+| `TaskID` (string) | `struct TaskId(String)` | Newtype; `Display`, `From<String>`, `AsRef<str>` |
+| `ArtifactID` (string) | `struct ArtifactId(String)` | Newtype |
+| `MessageID` (string) | `struct MessageId(String)` | Newtype |
+| `ContextID` (string) | `struct ContextId(String)` | Newtype |
+| `TaskVersion` (u64) | `struct TaskVersion(u64)` | Newtype; monotonic counter for optimistic concurrency |
+| `Metadata` (any JSON) | `serde_json::Value` | Untyped per spec |
+| Protocol version string | `struct ProtocolVersion(String)` | Validates `"0.3.0"` format |
+
+---
+
+## `task.rs`
+
+### `TaskState`
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TaskState {
+    Submitted,      // "submitted"
+    Working,        // "working"
+    InputRequired,  // "input-required"
+    AuthRequired,   // "auth-required"
+    Completed,      // "completed"
+    Failed,         // "failed"
+    Canceled,       // "canceled"
+    Rejected,       // "rejected"
+    Unknown,        // "unknown"
+}
+```
+
+Terminal states: `Completed | Failed | Canceled | Rejected`.
+
+### `TaskStatus`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `state` | `state` | `TaskState` | Yes |
+| `message` | `message` | `Option<Message>` | No |
+| `timestamp` | `timestamp` | `Option<String>` | No (ISO 8601) |
+
+### `Task`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `id` | `id` | `TaskId` | Yes |
+| `contextId` | `context_id` | `ContextId` | Yes |
+| `status` | `status` | `TaskStatus` | Yes |
+| `history` | `history` | `Option<Vec<Message>>` | No |
+| `artifacts` | `artifacts` | `Option<Vec<Artifact>>` | No |
+| `metadata` | `metadata` | `Option<serde_json::Value>` | No |
+| `kind` | `kind` | `TaskKind` | Yes (always `"task"`) |
+
+```rust
+// Phantom discriminator — always serializes as "task"
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TaskKind;
+impl TaskKind {
+    const VALUE: &'static str = "task";
+}
+// OR simpler:
+#[serde(rename = "kind")]
+pub kind: &'static str,  // hardcoded "task"
+```
+
+---
+
+## `message.rs`
+
+### `MessageRole`
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MessageRole {
+    User,   // "user"
+    Agent,  // "agent"
+}
+```
+
+### `Message`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `messageId` | `id` | `MessageId` | Yes |
+| `taskId` | `task_id` | `Option<TaskId>` | No |
+| `contextId` | `context_id` | `Option<ContextId>` | No |
+| `role` | `role` | `MessageRole` | Yes |
+| `parts` | `parts` | `Vec<Part>` | Yes (non-empty) |
+| `referenceTaskIds` | `reference_task_ids` | `Option<Vec<TaskId>>` | No |
+| `extensions` | `extensions` | `Option<Vec<String>>` | No (URIs) |
+| `metadata` | `metadata` | `Option<serde_json::Value>` | No |
+| `kind` | `kind` | `MessageKind` | Yes (always `"message"`) |
+
+### `Part` (discriminated union, tag = `"kind"`)
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum Part {
+    Text(TextPart),
+    File(FilePart),
+    Data(DataPart),
+}
+```
+
+### `TextPart`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `text` | `text` | `String` | Yes |
+| `metadata` | `metadata` | `Option<serde_json::Value>` | No |
+
+### `FilePart`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `file` | `file` | `FileContent` | Yes |
+| `metadata` | `metadata` | `Option<serde_json::Value>` | No |
+
+### `FileContent` (untagged union — presence of `bytes` vs `uri` field)
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum FileContent {
+    Bytes(FileWithBytes),  // deserializes when `bytes` key present
+    Uri(FileWithUri),      // deserializes when `uri` key present
+}
+```
+
+### `FileWithBytes`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `name` | `name` | `Option<String>` | No |
+| `mimeType` | `mime_type` | `Option<String>` | No |
+| `bytes` | `bytes` | `String` | Yes (base64-encoded) |
+
+Note: base64 encode/decode implemented in-tree in `a2a-types/src/base64.rs` (~40 lines). No `base64` crate dep.
+
+### `FileWithUri`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `name` | `name` | `Option<String>` | No |
+| `mimeType` | `mime_type` | `Option<String>` | No |
+| `uri` | `uri` | `String` | Yes (absolute URL preferred) |
+
+### `DataPart`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `data` | `data` | `serde_json::Value` | Yes (object) |
+| `metadata` | `metadata` | `Option<serde_json::Value>` | No |
+
+---
+
+## `artifact.rs`
+
+### `Artifact`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `artifactId` | `id` | `ArtifactId` | Yes |
+| `name` | `name` | `Option<String>` | No |
+| `description` | `description` | `Option<String>` | No |
+| `parts` | `parts` | `Vec<Part>` | Yes (non-empty) |
+| `extensions` | `extensions` | `Option<Vec<String>>` | No (URIs) |
+| `metadata` | `metadata` | `Option<serde_json::Value>` | No |
+
+---
+
+## `events.rs`
+
+### `TaskStatusUpdateEvent`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `taskId` | `task_id` | `TaskId` | Yes |
+| `contextId` | `context_id` | `ContextId` | Yes |
+| `state` | `state` | `TaskState` | Yes |
+| `message` | `message` | `Option<Message>` | No |
+| `metadata` | `metadata` | `Option<serde_json::Value>` | No |
+| `kind` | `kind` | `"status-update"` | Yes |
+| `final` | `r#final` | `bool` | Yes |
+
+Note: `final` is a Rust keyword; use raw identifier `r#final`. In serde, use `#[serde(rename = "final")]`.
+
+### `TaskArtifactUpdateEvent`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `taskId` | `task_id` | `TaskId` | Yes |
+| `contextId` | `context_id` | `ContextId` | Yes |
+| `artifact` | `artifact` | `Artifact` | Yes |
+| `append` | `append` | `Option<bool>` | No |
+| `lastChunk` | `last_chunk` | `Option<bool>` | No |
+| `metadata` | `metadata` | `Option<serde_json::Value>` | No |
+| `kind` | `kind` | `"artifact-update"` | Yes |
+
+### `StreamResponse` (discriminated union, tag = `"kind"`)
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum StreamResponse {
+    Task(Task),                                    // "task"
+    Message(Message),                              // "message"
+    #[serde(rename = "status-update")]
+    StatusUpdate(TaskStatusUpdateEvent),
+    #[serde(rename = "artifact-update")]
+    ArtifactUpdate(TaskArtifactUpdateEvent),
+}
+```
+
+---
+
+## `agent_card.rs`
+
+### `TransportProtocol`
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TransportProtocol {
+    JsonRpc,   // "JSONRPC"
+    Grpc,      // "GRPC"
+    Rest,      // "REST"
+}
+```
+
+### `AgentInterface`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `url` | `url` | `String` | Yes |
+| `transport` | `transport` | `TransportProtocol` | Yes |
+
+### `AgentCapabilities`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `streaming` | `streaming` | `Option<bool>` | No |
+| `pushNotifications` | `push_notifications` | `Option<bool>` | No |
+| `stateTransitionHistory` | `state_transition_history` | `Option<bool>` | No |
+| `extensions` | `extensions` | `Option<Vec<AgentExtension>>` | No |
+
+### `AgentProvider`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `organization` | `organization` | `String` | Yes |
+| `url` | `url` | `String` | Yes |
+
+### `AgentSkill`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `id` | `id` | `String` | Yes |
+| `name` | `name` | `String` | Yes |
+| `description` | `description` | `String` | Yes |
+| `tags` | `tags` | `Vec<String>` | Yes |
+| `examples` | `examples` | `Option<Vec<String>>` | No |
+| `inputModes` | `input_modes` | `Option<Vec<String>>` | No (MIME types) |
+| `outputModes` | `output_modes` | `Option<Vec<String>>` | No (MIME types) |
+| `security` | `security` | `Option<SecurityRequirements>` | No |
+
+### `AgentCard`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `protocolVersion` | `protocol_version` | `String` | Yes |
+| `name` | `name` | `String` | Yes |
+| `description` | `description` | `String` | Yes |
+| `version` | `version` | `String` | Yes |
+| `url` | `url` | `String` | Yes (base RPC endpoint) |
+| `preferredTransport` | `preferred_transport` | `TransportProtocol` | Yes |
+| `additionalInterfaces` | `additional_interfaces` | `Option<Vec<AgentInterface>>` | No |
+| `defaultInputModes` | `default_input_modes` | `Vec<String>` | Yes (MIME types) |
+| `defaultOutputModes` | `default_output_modes` | `Vec<String>` | Yes (MIME types) |
+| `skills` | `skills` | `Vec<AgentSkill>` | Yes |
+| `capabilities` | `capabilities` | `AgentCapabilities` | Yes |
+| `provider` | `provider` | `Option<AgentProvider>` | No |
+| `iconUrl` | `icon_url` | `Option<String>` | No |
+| `documentationUrl` | `documentation_url` | `Option<String>` | No |
+| `securitySchemes` | `security_schemes` | `Option<NamedSecuritySchemes>` | No |
+| `security` | `security` | `Option<SecurityRequirements>` | No |
+| `supportsAuthenticatedExtendedCard` | `supports_authenticated_extended_card` | `Option<bool>` | No |
+| `signatures` | `signatures` | `Option<Vec<AgentCardSignature>>` | No |
+
+`NamedSecuritySchemes` = `HashMap<String, SecurityScheme>`.
+`SecurityRequirements` = `Vec<HashMap<String, Vec<String>>>` (OpenAPI style).
+
+---
+
+## `security.rs`
+
+### `SecurityScheme` (discriminated union, tag = `"type"`)
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum SecurityScheme {
+    #[serde(rename = "apiKey")]
+    ApiKey(ApiKeySecurityScheme),
+    #[serde(rename = "http")]
+    Http(HttpAuthSecurityScheme),
+    #[serde(rename = "oauth2")]
+    OAuth2(OAuth2SecurityScheme),
+    #[serde(rename = "openIdConnect")]
+    OpenIdConnect(OpenIdConnectSecurityScheme),
+    #[serde(rename = "mutualTLS")]
+    MutualTls(MutualTlsSecurityScheme),
+}
+```
+
+### `ApiKeySecurityScheme`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `in` | `location` | `ApiKeyLocation` | Yes |
+| `name` | `name` | `String` | Yes |
+| `description` | `description` | `Option<String>` | No |
+
+```rust
+#[serde(rename_all = "lowercase")]
+pub enum ApiKeyLocation { Header, Query, Cookie }
+```
+
+### `HttpAuthSecurityScheme`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `scheme` | `scheme` | `String` | Yes (e.g., `"bearer"`, `"basic"`) |
+| `bearerFormat` | `bearer_format` | `Option<String>` | No (e.g., `"JWT"`) |
+| `description` | `description` | `Option<String>` | No |
+
+### `OAuth2SecurityScheme`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `flows` | `flows` | `OAuthFlows` | Yes |
+| `oauth2MetadataUrl` | `oauth2_metadata_url` | `Option<String>` | No |
+| `description` | `description` | `Option<String>` | No |
+
+### `OAuthFlows`
+
+```rust
+pub struct OAuthFlows {
+    pub authorization_code: Option<AuthorizationCodeFlow>,
+    pub client_credentials: Option<ClientCredentialsFlow>,
+    pub device_code:        Option<DeviceCodeFlow>,
+    pub implicit:           Option<ImplicitFlow>,
+}
+```
+
+Each flow type mirrors the OpenAPI 3.x OAuth2 flow structure.
+
+### `OpenIdConnectSecurityScheme`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `openIdConnectUrl` | `open_id_connect_url` | `String` | Yes |
+| `description` | `description` | `Option<String>` | No |
+
+### `MutualTlsSecurityScheme`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `description` | `description` | `Option<String>` | No |
+
+---
+
+## `push.rs`
+
+### `PushNotificationAuthInfo`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `schemes` | `schemes` | `Vec<String>` | Yes (e.g., `["bearer"]`) |
+| `credentials` | `credentials` | `Option<String>` | No |
+
+### `PushNotificationConfig`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `id` | `id` | `Option<String>` | No (server-assigned) |
+| `url` | `url` | `String` | Yes (HTTPS webhook) |
+| `token` | `token` | `Option<String>` | No (shared secret) |
+| `authentication` | `authentication` | `Option<PushNotificationAuthInfo>` | No |
+
+### `TaskPushNotificationConfig`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `taskId` | `task_id` | `TaskId` | Yes |
+| `pushNotificationConfig` | `push_notification_config` | `PushNotificationConfig` | Yes |
+
+---
+
+## `params.rs`
+
+### `SendMessageConfiguration`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `acceptedOutputModes` | `accepted_output_modes` | `Vec<String>` | Yes (MIME types) |
+| `taskPushNotificationConfig` | `task_push_notification_config` | `Option<TaskPushNotificationConfig>` | No |
+| `historyLength` | `history_length` | `Option<u32>` | No |
+| `returnImmediately` | `return_immediately` | `Option<bool>` | No |
+
+### `MessageSendParams`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `message` | `message` | `Message` | Yes |
+| `configuration` | `configuration` | `Option<SendMessageConfiguration>` | No |
+| `metadata` | `metadata` | `Option<serde_json::Value>` | No |
+
+### `TaskQueryParams`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `id` | `id` | `TaskId` | Yes |
+| `historyLength` | `history_length` | `Option<u32>` | No |
+
+### `TaskIdParams`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `id` | `id` | `TaskId` | Yes |
+
+### `ListTasksParams`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `contextId` | `context_id` | `Option<ContextId>` | No |
+| `status` | `status` | `Option<TaskState>` | No (filter) |
+| `pageSize` | `page_size` | `Option<u32>` | No (1–100, default 50) |
+| `pageToken` | `page_token` | `Option<String>` | No (cursor) |
+| `statusTimestampAfter` | `status_timestamp_after` | `Option<String>` | No (ISO 8601) |
+| `includeArtifacts` | `include_artifacts` | `Option<bool>` | No |
+
+### `GetPushConfigParams`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `taskId` | `task_id` | `TaskId` | Yes |
+| `id` | `id` | `String` | Yes (config ID) |
+
+### `DeletePushConfigParams`
+
+Same fields as `GetPushConfigParams`.
+
+---
+
+## `responses.rs`
+
+### `SendMessageResponse` (untagged union — either Task or Message, disambiguated by `kind` field)
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum SendMessageResponse {
+    Task(Task),       // "task"
+    Message(Message), // "message"
+}
+```
+
+### `TaskListResponse`
+
+| Field | Type | Notes |
+|---|---|---|
+| `tasks` | `Vec<Task>` | Paginated results |
+| `next_page_token` | `Option<String>` | Absent on last page |
+
+### `AuthenticatedExtendedCardResponse`
+
+The full (private) `AgentCard` returned only to authenticated callers via `agent/authenticatedExtendedCard`.
+Type alias: `AgentCard` (same structure; no additional fields in spec 0.3.0).
+
+---
+
+## `extensions.rs`
+
+### `AgentExtension`
+
+| Spec field | Rust field | Type | Required |
+|---|---|---|---|
+| `uri` | `uri` | `String` | Yes (unique identifier) |
+| `description` | `description` | `Option<String>` | No |
+| `required` | `required` | `Option<bool>` | No |
+| `params` | `params` | `Option<serde_json::Value>` | No |
+
+### `AgentCardSignature`
+
+Structure is spec-defined as an object; exact fields are extension-point. Initial implementation uses `serde_json::Value` until the spec firms up the format.
+
+---
+
+## `jsonrpc.rs`
+
+### `JsonRpcVersion`
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcVersion;
+// Always serializes/deserializes as the string "2.0"
+// Deserializer rejects any other value
+```
+
+### `JsonRpcId`
+
+```rust
+pub type JsonRpcId = Option<serde_json::Value>;
+// Valid values per JSON-RPC 2.0: string, number, or null
+// Notification: id field absent entirely
+```
+
+### `JsonRpcRequest`
+
+| Field | Rust type | Notes |
+|---|---|---|
+| `jsonrpc` | `JsonRpcVersion` | Must be `"2.0"` |
+| `id` | `JsonRpcId` | `None` = notification (no response expected) |
+| `method` | `String` | A2A method name |
+| `params` | `Option<serde_json::Value>` | Method-specific params |
+
+### `JsonRpcResponse<T>` (untagged — either success or error)
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum JsonRpcResponse<T> {
+    Success(JsonRpcSuccessResponse<T>),
+    Error(JsonRpcErrorResponse),
+}
+```
+
+Disambiguation: `JsonRpcErrorResponse` has an `error` field; `JsonRpcSuccessResponse` has a `result` field. The `untagged` enum tries `Success` first; falls back to `Error` if `result` field is absent.
+
+---
+
+## Serde Annotation Summary
+
+| Pattern | Usage |
+|---|---|
+| `#[serde(rename_all = "camelCase")]` | All protocol structs (spec uses camelCase) |
+| `#[serde(rename_all = "kebab-case")]` | `TaskState` enum (spec uses `"kebab-case"`) |
+| `#[serde(rename_all = "lowercase")]` | `MessageRole`, `ApiKeyLocation` |
+| `#[serde(tag = "kind")]` | `Part`, `StreamResponse`, `SendMessageResponse` |
+| `#[serde(tag = "type")]` | `SecurityScheme` |
+| `#[serde(untagged)]` | `FileContent`, `JsonRpcResponse<T>` |
+| `#[serde(skip_serializing_if = "Option::is_none")]` | All `Option<T>` fields |
+| `#[serde(rename = "final")]` | `TaskStatusUpdateEvent.r#final` (keyword conflict) |
+| `#[serde(rename = "in")]` | `ApiKeySecurityScheme.location` (`in` is a keyword) |
+| `#[serde(default)]` | Boolean fields defaulting to `false` |
+
+---
+
+## Non-Obvious Rust-Specific Decisions
+
+### `final` and `in` as Keywords
+
+Two spec field names conflict with Rust keywords:
+- `final` (in `TaskStatusUpdateEvent`) → Rust field `r#final`, serde `#[serde(rename = "final")]`
+- `in` (in `ApiKeySecurityScheme`) → Rust field `location`, serde `#[serde(rename = "in")]`
+
+### ID Newtypes vs. `String`
+
+All ID types are newtypes over `String` rather than raw `String`. This provides:
+- Compile-time prevention of passing a `MessageId` where a `TaskId` is expected.
+- A place to add validation (UUID format) without breaking the public API.
+- Clear intent in function signatures.
+
+### `serde_json::Value` for Open-Ended Fields
+
+Fields specified as `any JSON object` in the spec (`metadata`, `data`, `params`) use `serde_json::Value`. This avoids carrying an `serde_json::Map<String, Value>` explicitly and handles both `null` and structured data.
+
+### `#[derive(Clone)]` on All Types
+
+All protocol types derive `Clone`. This is necessary for server-side code that must hold tasks in stores while also returning them in responses.
+
+### `Copy` on Enums
+
+`TaskState`, `MessageRole`, `ApiKeyLocation`, `TransportProtocol` derive `Copy`. They are discriminants with no heap allocation.
+
+---
+
+*Document version: 1.0*
+*Last updated: 2026-03-15*


### PR DESCRIPTION
## Summary

This PR adds complete implementation planning and architectural documentation for the a2a-rust SDK, establishing the foundation for development of a production-grade A2A 0.3.0 protocol implementation in Rust.

## Key Changes

- **`docs/implementation/plan.md`** — Comprehensive 1133-line implementation roadmap covering:
  - Project goals (full spec compliance, enterprise-grade error handling, minimal footprint, modern Rust idioms)
  - Dependency philosophy with explicit rationale for each mandatory and excluded dependency
  - Complete workspace and crate structure (a2a-types, a2a-client, a2a-server, a2a-sdk)
  - Detailed architecture overview with 3-layer server design and client architecture
  - Complete file inventory with line count estimates and single-responsibility descriptions
  - Seven implementation phases from project foundation through quality gates and release
  - Testing strategy (unit, integration, property-based, E2E)
  - Quality gates and coding standards (500-line file cap, zero unsafe, no panics at boundaries)

- **`docs/implementation/type-mapping.md`** — Field-by-field mapping from A2A 0.3.0 JSON schema to Rust types:
  - Primitive and alias types (TaskId, ArtifactId, TaskVersion as newtypes)
  - Complete struct definitions with serde annotations for all protocol types
  - Discriminated union patterns (Part, StreamResponse, SecurityScheme)
  - Untagged union handling (FileContent, JsonRpcResponse)
  - Special cases (raw identifiers for `final` keyword, base64 encoding strategy)

- **`docs/adr/0001-workspace-crate-structure.md`** — Architecture Decision Record establishing four-crate separation:
  - Rationale for splitting types, client, and server into independent crates
  - Dependency isolation benefits for different user personas
  - Future extensibility for gRPC transport without forcing deps on HTTP-only users

- **`docs/adr/0002-dependency-philosophy.md`** — Explicit dependency strategy:
  - Mandatory runtime deps table (serde, tokio, hyper, uuid) with justification
  - Optional feature-gated deps (tracing, rustls)
  - Explicitly excluded deps with rationale (reqwest, anyhow, thiserror, openssl-sys, log)
  - Supply chain risk mitigation approach

- **`docs/adr/0003-async-runtime-strategy.md`** — Async/await design decisions:
  - Tokio as mandatory runtime with minimal feature set
  - Use of `async fn` in traits (stable since Rust 1.75)
  - No blocking operations at I/O boundaries
  - Support for single-threaded and multi-threaded runtimes

- **`docs/adr/0004-transport-abstraction.md`** — Transport layer design:
  - Client-side Transport trait for pluggable HTTP backends
  - Concrete implementations for JSON-RPC and REST transports
  - Server-side transport adapters (JsonRpcHandler, RestHandler)
  - Framework-agnostic integration pattern

- **`docs/adr/0005-sse-streaming-design.md`** — Server-Sent Events implementation:
  - In-tree SSE parser and emitter (zero additional deps)
  - Client-side byte-stream state machine for SSE parsing
  - Server-side SseResponseBuilder with keep-alive support
  - Backpressure handling via tokio channels

## Notable Implementation Details

- **Strict modularity**: 500-line file cap enforced across all crates
- **Zero unsafe code** except at true FFI boundaries (with mandatory `// SAFETY:` comments)
- **No panics at boundaries**: All public APIs return `Result<T, E>` with typed error variants
- **Minimal footprint**: Only serde/serde_json mandatory; all I/O deps optional or feature-gated
- **Modern Rust idioms**: Edition 2021, async/await, `impl Trait`, `LazyLock`
- **Complete test coverage**: Four-layer strategy (unit, integration, property-based, E2E)
- **Enterprise

https://claude.ai/code/session_01W5ZBLYkLsD4fH6XArBGHpn