### PR TITLE
Add comprehensive A2A 0.3.0 protocol type definitions

### DIFF
--- a/crates/a2a-types/src/agent_card.rs
+++ b/crates/a2a-types/src/agent_card.rs
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Tom F.
+
+//! Agent card and capability discovery types.
+//!
+//! The [`AgentCard`] is the root discovery document served by an A2A agent at
+//! `/.well-known/agent-card.json`. It describes the agent's identity,
+//! capabilities, skills, security requirements, and transport preferences.
+//!
+//! # Transport protocol
+//!
+//! [`TransportProtocol`] uses `SCREAMING_SNAKE_CASE`-adjacent serialization.
+//! `JSONRPC` and `GRPC` do not contain underscores in their wire representations,
+//! so explicit `#[serde(rename)]` attributes are used where the derive would
+//! produce a different result.
+
+use serde::{Deserialize, Serialize};
+
+use crate::extensions::{AgentCardSignature, AgentExtension};
+use crate::security::{NamedSecuritySchemes, SecurityRequirements};
+
+// ── TransportProtocol ─────────────────────────────────────────────────────────
+
+/// The transport protocol used by an agent interface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum TransportProtocol {
+    /// JSON-RPC 2.0 over HTTP(S).
+    #[serde(rename = "JSONRPC")]
+    JsonRpc,
+
+    /// gRPC.
+    #[serde(rename = "GRPC")]
+    Grpc,
+
+    /// HTTP REST.
+    #[serde(rename = "REST")]
+    Rest,
+}
+
+// ── AgentInterface ────────────────────────────────────────────────────────────
+
+/// An alternative transport interface offered by an agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentInterface {
+    /// Base URL of this interface endpoint.
+    pub url: String,
+
+    /// Transport protocol for this interface.
+    pub transport: TransportProtocol,
+}
+
+// ── AgentCapabilities ─────────────────────────────────────────────────────────
+
+/// Optional capability flags advertised by an agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCapabilities {
+    /// Whether the agent supports streaming via `message/stream`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub streaming: Option<bool>,
+
+    /// Whether the agent supports push notification delivery.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub push_notifications: Option<bool>,
+
+    /// Whether the agent retains full state-transition history.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_transition_history: Option<bool>,
+
+    /// Optional extensions supported by this agent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<Vec<AgentExtension>>,
+}
+
+impl AgentCapabilities {
+    /// Creates an [`AgentCapabilities`] with all flags unset.
+    #[must_use]
+    pub const fn none() -> Self {
+        Self {
+            streaming: None,
+            push_notifications: None,
+            state_transition_history: None,
+            extensions: None,
+        }
+    }
+}
+
+// ── AgentProvider ─────────────────────────────────────────────────────────────
+
+/// The organization that operates or publishes the agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentProvider {
+    /// Name of the organization.
+    pub organization: String,
+
+    /// URL of the organization's website.
+    pub url: String,
+}
+
+// ── AgentSkill ────────────────────────────────────────────────────────────────
+
+/// A discrete capability offered by an agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentSkill {
+    /// Unique skill identifier within the agent.
+    pub id: String,
+
+    /// Human-readable skill name.
+    pub name: String,
+
+    /// Human-readable description of what the skill does.
+    pub description: String,
+
+    /// Searchable tags for the skill.
+    pub tags: Vec<String>,
+
+    /// Example prompts illustrating how to invoke the skill.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub examples: Option<Vec<String>>,
+
+    /// MIME types accepted as input by this skill.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_modes: Option<Vec<String>>,
+
+    /// MIME types produced as output by this skill.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_modes: Option<Vec<String>>,
+
+    /// Security requirements specific to this skill.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub security: Option<SecurityRequirements>,
+}
+
+// ── AgentCard ─────────────────────────────────────────────────────────────────
+
+/// The root discovery document for an A2A agent.
+///
+/// Served at `/.well-known/agent-card.json`. Clients fetch this document to
+/// discover the agent's endpoint URL, capabilities, skills, and security
+/// requirements before establishing a session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCard {
+    /// A2A protocol version string (e.g. `"0.3.0"`).
+    pub protocol_version: String,
+
+    /// Display name of the agent.
+    pub name: String,
+
+    /// Human-readable description of the agent's purpose.
+    pub description: String,
+
+    /// Semantic version of this agent implementation.
+    pub version: String,
+
+    /// Base URL of the agent's primary RPC endpoint.
+    pub url: String,
+
+    /// Preferred transport protocol.
+    pub preferred_transport: TransportProtocol,
+
+    /// Additional transport interfaces offered by this agent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub additional_interfaces: Option<Vec<AgentInterface>>,
+
+    /// Default MIME types accepted as input.
+    pub default_input_modes: Vec<String>,
+
+    /// Default MIME types produced as output.
+    pub default_output_modes: Vec<String>,
+
+    /// Skills offered by this agent.
+    pub skills: Vec<AgentSkill>,
+
+    /// Capability flags.
+    pub capabilities: AgentCapabilities,
+
+    /// The organization operating this agent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<AgentProvider>,
+
+    /// URL of the agent's icon image.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_url: Option<String>,
+
+    /// URL of the agent's documentation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub documentation_url: Option<String>,
+
+    /// Named security scheme definitions (OpenAPI-style).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub security_schemes: Option<NamedSecuritySchemes>,
+
+    /// Global security requirements for the agent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub security: Option<SecurityRequirements>,
+
+    /// Whether this agent serves an authenticated extended card.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supports_authenticated_extended_card: Option<bool>,
+
+    /// Cryptographic signatures over this card.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signatures: Option<Vec<AgentCardSignature>>,
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal_card() -> AgentCard {
+        AgentCard {
+            protocol_version: "0.3.0".into(),
+            name: "Test Agent".into(),
+            description: "A test agent".into(),
+            version: "1.0.0".into(),
+            url: "https://agent.example.com/rpc".into(),
+            preferred_transport: TransportProtocol::JsonRpc,
+            additional_interfaces: None,
+            default_input_modes: vec!["text/plain".into()],
+            default_output_modes: vec!["text/plain".into()],
+            skills: vec![AgentSkill {
+                id: "echo".into(),
+                name: "Echo".into(),
+                description: "Echoes input".into(),
+                tags: vec!["echo".into()],
+                examples: None,
+                input_modes: None,
+                output_modes: None,
+                security: None,
+            }],
+            capabilities: AgentCapabilities::none(),
+            provider: None,
+            icon_url: None,
+            documentation_url: None,
+            security_schemes: None,
+            security: None,
+            supports_authenticated_extended_card: None,
+            signatures: None,
+        }
+    }
+
+    #[test]
+    fn transport_protocol_serialization() {
+        assert_eq!(
+            serde_json::to_string(&TransportProtocol::JsonRpc).expect("ser"),
+            "\"JSONRPC\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TransportProtocol::Grpc).expect("ser"),
+            "\"GRPC\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TransportProtocol::Rest).expect("ser"),
+            "\"REST\""
+        );
+    }
+
+    #[test]
+    fn transport_protocol_deserialization() {
+        let p: TransportProtocol = serde_json::from_str("\"JSONRPC\"").expect("deser");
+        assert_eq!(p, TransportProtocol::JsonRpc);
+    }
+
+    #[test]
+    fn agent_card_roundtrip() {
+        let card = minimal_card();
+        let json = serde_json::to_string(&card).expect("serialize");
+        assert!(json.contains("\"protocolVersion\":\"0.3.0\""));
+        assert!(json.contains("\"preferredTransport\":\"JSONRPC\""));
+
+        let back: AgentCard = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.name, "Test Agent");
+        assert_eq!(back.preferred_transport, TransportProtocol::JsonRpc);
+    }
+
+    #[test]
+    fn optional_fields_omitted() {
+        let card = minimal_card();
+        let json = serde_json::to_string(&card).expect("serialize");
+        assert!(!json.contains("\"provider\""), "provider should be absent");
+        assert!(!json.contains("\"iconUrl\""), "iconUrl should be absent");
+        assert!(
+            !json.contains("\"securitySchemes\""),
+            "securitySchemes should be absent"
+        );
+    }
+}

--- a/crates/a2a-types/src/artifact.rs
+++ b/crates/a2a-types/src/artifact.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Tom F.
+
+//! Artifact types for the A2A protocol.
+//!
+//! An [`Artifact`] represents a discrete output produced by an agent — for
+//! example a generated file, a code snippet, or a structured result. Artifacts
+//! are carried in [`crate::task::Task::artifacts`] and in
+//! [`crate::events::TaskArtifactUpdateEvent`].
+
+use serde::{Deserialize, Serialize};
+
+use crate::message::Part;
+
+// ── ArtifactId ────────────────────────────────────────────────────────────────
+
+/// Opaque unique identifier for an [`Artifact`].
+///
+/// Wraps a `String` for compile-time type safety.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ArtifactId(pub String);
+
+impl ArtifactId {
+    /// Creates a new [`ArtifactId`] from any string-like value.
+    #[must_use]
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+}
+
+impl std::fmt::Display for ArtifactId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for ArtifactId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for ArtifactId {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
+impl AsRef<str> for ArtifactId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+// ── Artifact ──────────────────────────────────────────────────────────────────
+
+/// An output artifact produced by an agent.
+///
+/// Each artifact has a unique [`ArtifactId`] and carries its content as a
+/// non-empty list of [`Part`] values.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Artifact {
+    /// Unique artifact identifier.
+    #[serde(rename = "artifactId")]
+    pub id: ArtifactId,
+
+    /// Optional human-readable name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    /// Optional human-readable description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Content parts (must contain at least one element).
+    pub parts: Vec<Part>,
+
+    /// URIs of extensions used in this artifact.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<Vec<String>>,
+
+    /// Arbitrary metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+impl Artifact {
+    /// Creates a minimal [`Artifact`] with an ID and a single part.
+    #[must_use]
+    pub fn new(id: impl Into<ArtifactId>, parts: Vec<Part>) -> Self {
+        Self {
+            id: id.into(),
+            name: None,
+            description: None,
+            parts,
+            extensions: None,
+            metadata: None,
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::{Part, TextPart};
+
+    #[test]
+    fn artifact_roundtrip() {
+        let artifact = Artifact::new("art-1", vec![Part::Text(TextPart::new("result content"))]);
+        let json = serde_json::to_string(&artifact).expect("serialize");
+        assert!(json.contains("\"artifactId\":\"art-1\""));
+        assert!(json.contains("\"kind\":\"text\""));
+
+        let back: Artifact = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.id, ArtifactId::new("art-1"));
+        assert_eq!(back.parts.len(), 1);
+    }
+
+    #[test]
+    fn optional_fields_omitted() {
+        let artifact = Artifact::new("art-2", vec![Part::Text(TextPart::new("x"))]);
+        let json = serde_json::to_string(&artifact).expect("serialize");
+        assert!(!json.contains("\"name\""), "name should be omitted");
+        assert!(
+            !json.contains("\"description\""),
+            "description should be omitted"
+        );
+        assert!(!json.contains("\"metadata\""), "metadata should be omitted");
+    }
+
+    #[test]
+    fn artifact_id_display() {
+        let id = ArtifactId::new("my-artifact");
+        assert_eq!(id.to_string(), "my-artifact");
+    }
+}

--- a/crates/a2a-types/src/error.rs
+++ b/crates/a2a-types/src/error.rs
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Tom F.
+
+//! A2A protocol error types.
+//!
+//! This module defines [`A2aError`], the canonical error type for all A2A
+//! protocol operations, along with [`ErrorCode`] carrying every standard error
+//! code defined by A2A 0.3.0 and the underlying JSON-RPC 2.0 specification.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+// ── Error codes ──────────────────────────────────────────────────────────────
+
+/// Numeric error codes defined by JSON-RPC 2.0 and the A2A 0.3.0 specification.
+///
+/// JSON-RPC standard codes occupy the `-32700` to `-32600` range.
+/// A2A-specific codes occupy `-32001` to `-32099`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(into = "i32", try_from = "i32")]
+#[non_exhaustive]
+pub enum ErrorCode {
+    // ── JSON-RPC 2.0 standard ─────────────────────────────────────────────
+    /// Invalid JSON was received by the server (`-32700`).
+    ParseError = -32700,
+    /// The JSON sent is not a valid Request object (`-32600`).
+    InvalidRequest = -32600,
+    /// The method does not exist or is not available (`-32601`).
+    MethodNotFound = -32601,
+    /// Invalid method parameters (`-32602`).
+    InvalidParams = -32602,
+    /// Internal JSON-RPC error (`-32603`).
+    InternalError = -32603,
+
+    // ── A2A-specific ──────────────────────────────────────────────────────
+    /// The requested task was not found (`-32001`).
+    TaskNotFound = -32001,
+    /// The task cannot be canceled in its current state (`-32002`).
+    TaskNotCancelable = -32002,
+    /// The agent does not support push notifications (`-32003`).
+    PushNotificationNotSupported = -32003,
+    /// The requested operation is not supported by this agent (`-32004`).
+    UnsupportedOperation = -32004,
+    /// The requested content type is not supported (`-32005`).
+    ContentTypeNotSupported = -32005,
+    /// The requested protocol version is not supported (`-32006`).
+    VersionNotSupported = -32006,
+    /// A required extension is not supported (`-32007`).
+    ExtensionSupportRequired = -32007,
+    /// The message is invalid (`-32008`).
+    InvalidMessage = -32008,
+    /// Authentication failed (`-32009`).
+    AuthenticationFailed = -32009,
+    /// Authorization failed (`-32010`).
+    AuthorizationFailed = -32010,
+    /// The requested mode is not supported (`-32011`).
+    UnsupportedMode = -32011,
+}
+
+impl ErrorCode {
+    /// Returns the numeric value of this error code.
+    #[must_use]
+    pub const fn as_i32(self) -> i32 {
+        self as i32
+    }
+
+    /// Returns a short human-readable description of the code.
+    #[must_use]
+    pub const fn default_message(self) -> &'static str {
+        match self {
+            Self::ParseError => "Parse error",
+            Self::InvalidRequest => "Invalid request",
+            Self::MethodNotFound => "Method not found",
+            Self::InvalidParams => "Invalid params",
+            Self::InternalError => "Internal error",
+            Self::TaskNotFound => "Task not found",
+            Self::TaskNotCancelable => "Task not cancelable",
+            Self::PushNotificationNotSupported => "Push notification not supported",
+            Self::UnsupportedOperation => "Unsupported operation",
+            Self::ContentTypeNotSupported => "Content type not supported",
+            Self::VersionNotSupported => "Version not supported",
+            Self::ExtensionSupportRequired => "Extension support required",
+            Self::InvalidMessage => "Invalid message",
+            Self::AuthenticationFailed => "Authentication failed",
+            Self::AuthorizationFailed => "Authorization failed",
+            Self::UnsupportedMode => "Unsupported mode",
+        }
+    }
+}
+
+impl From<ErrorCode> for i32 {
+    fn from(code: ErrorCode) -> Self {
+        code as Self
+    }
+}
+
+impl TryFrom<i32> for ErrorCode {
+    type Error = i32;
+
+    fn try_from(v: i32) -> Result<Self, Self::Error> {
+        match v {
+            -32700 => Ok(Self::ParseError),
+            -32600 => Ok(Self::InvalidRequest),
+            -32601 => Ok(Self::MethodNotFound),
+            -32602 => Ok(Self::InvalidParams),
+            -32603 => Ok(Self::InternalError),
+            -32001 => Ok(Self::TaskNotFound),
+            -32002 => Ok(Self::TaskNotCancelable),
+            -32003 => Ok(Self::PushNotificationNotSupported),
+            -32004 => Ok(Self::UnsupportedOperation),
+            -32005 => Ok(Self::ContentTypeNotSupported),
+            -32006 => Ok(Self::VersionNotSupported),
+            -32007 => Ok(Self::ExtensionSupportRequired),
+            -32008 => Ok(Self::InvalidMessage),
+            -32009 => Ok(Self::AuthenticationFailed),
+            -32010 => Ok(Self::AuthorizationFailed),
+            -32011 => Ok(Self::UnsupportedMode),
+            other => Err(other),
+        }
+    }
+}
+
+impl fmt::Display for ErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} ({})", self.default_message(), self.as_i32())
+    }
+}
+
+// ── A2aError ──────────────────────────────────────────────────────────────────
+
+/// The canonical error type for A2A protocol operations.
+///
+/// Carries an [`ErrorCode`], a human-readable `message`, and an optional
+/// `data` payload (arbitrary JSON) for additional diagnostics.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct A2aError {
+    /// Machine-readable error code.
+    pub code: ErrorCode,
+    /// Human-readable error message.
+    pub message: String,
+    /// Optional structured error details.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+impl A2aError {
+    /// Creates a new `A2aError` with the given code and message.
+    #[must_use]
+    pub fn new(code: ErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            data: None,
+        }
+    }
+
+    /// Creates a new `A2aError` with the given code, message, and data.
+    #[must_use]
+    pub fn with_data(code: ErrorCode, message: impl Into<String>, data: serde_json::Value) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            data: Some(data),
+        }
+    }
+
+    // ── Named constructors ────────────────────────────────────────────────
+
+    /// Creates a "Task not found" error for the given task ID string.
+    #[must_use]
+    pub fn task_not_found(task_id: impl fmt::Display) -> Self {
+        Self::new(
+            ErrorCode::TaskNotFound,
+            format!("Task not found: {task_id}"),
+        )
+    }
+
+    /// Creates a "Task not cancelable" error.
+    #[must_use]
+    pub fn task_not_cancelable(task_id: impl fmt::Display) -> Self {
+        Self::new(
+            ErrorCode::TaskNotCancelable,
+            format!("Task cannot be canceled: {task_id}"),
+        )
+    }
+
+    /// Creates an internal error with the provided message.
+    #[must_use]
+    pub fn internal(msg: impl Into<String>) -> Self {
+        Self::new(ErrorCode::InternalError, msg)
+    }
+
+    /// Creates an "Invalid params" error.
+    #[must_use]
+    pub fn invalid_params(msg: impl Into<String>) -> Self {
+        Self::new(ErrorCode::InvalidParams, msg)
+    }
+
+    /// Creates an "Unsupported operation" error.
+    #[must_use]
+    pub fn unsupported_operation(msg: impl Into<String>) -> Self {
+        Self::new(ErrorCode::UnsupportedOperation, msg)
+    }
+
+    /// Creates an "Authentication failed" error.
+    #[must_use]
+    pub fn authentication_failed(msg: impl Into<String>) -> Self {
+        Self::new(ErrorCode::AuthenticationFailed, msg)
+    }
+
+    /// Creates an "Authorization failed" error.
+    #[must_use]
+    pub fn authorization_failed(msg: impl Into<String>) -> Self {
+        Self::new(ErrorCode::AuthorizationFailed, msg)
+    }
+
+    /// Creates a "Parse error" error.
+    #[must_use]
+    pub fn parse_error(msg: impl Into<String>) -> Self {
+        Self::new(ErrorCode::ParseError, msg)
+    }
+
+    /// Creates an "Invalid message" error.
+    #[must_use]
+    pub fn invalid_message(msg: impl Into<String>) -> Self {
+        Self::new(ErrorCode::InvalidMessage, msg)
+    }
+}
+
+impl fmt::Display for A2aError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}] {}", self.code.as_i32(), self.message)
+    }
+}
+
+impl std::error::Error for A2aError {}
+
+// ── A2aResult ─────────────────────────────────────────────────────────────────
+
+/// Convenience type alias: `Result<T, A2aError>`.
+pub type A2aResult<T> = Result<T, A2aError>;
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_code_roundtrip() {
+        let code = ErrorCode::TaskNotFound;
+        let n: i32 = code.into();
+        assert_eq!(n, -32001);
+        assert_eq!(ErrorCode::try_from(n), Ok(ErrorCode::TaskNotFound));
+    }
+
+    #[test]
+    fn error_code_unknown_value() {
+        assert!(ErrorCode::try_from(-99999).is_err());
+    }
+
+    #[test]
+    fn a2a_error_display() {
+        let err = A2aError::task_not_found("abc123");
+        let s = err.to_string();
+        assert!(s.contains("-32001"), "expected code in display: {s}");
+        assert!(s.contains("abc123"), "expected task id in display: {s}");
+    }
+
+    #[test]
+    fn a2a_error_serialization() {
+        let err = A2aError::internal("something went wrong");
+        let json = serde_json::to_string(&err).expect("serialize");
+        let back: A2aError = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.code, ErrorCode::InternalError);
+        assert_eq!(back.message, "something went wrong");
+        assert!(back.data.is_none());
+    }
+
+    #[test]
+    fn a2a_error_with_data() {
+        let data = serde_json::json!({"detail": "extra info"});
+        let err = A2aError::with_data(ErrorCode::InvalidParams, "bad input", data.clone());
+        let json = serde_json::to_string(&err).expect("serialize");
+        assert!(json.contains("\"data\""), "data field should be present");
+        let back: A2aError = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.data, Some(data));
+    }
+}

--- a/crates/a2a-types/src/events.rs
+++ b/crates/a2a-types/src/events.rs
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Tom F.
+
+//! Server-sent event types for A2A streaming.
+//!
+//! When a client calls `message/stream` or `tasks/resubscribe`, the server
+//! responds with a stream of Server-Sent Events. Each event carries a
+//! [`StreamResponse`] JSON payload discriminated on the `"kind"` field.
+//!
+//! # Stream event variants
+//!
+//! | `kind` value | Rust type |
+//! |---|---|
+//! | `"task"` | [`crate::task::Task`] |
+//! | `"message"` | [`crate::message::Message`] |
+//! | `"status-update"` | [`TaskStatusUpdateEvent`] |
+//! | `"artifact-update"` | [`TaskArtifactUpdateEvent`] |
+
+use serde::{Deserialize, Serialize};
+
+use crate::artifact::Artifact;
+use crate::message::Message;
+use crate::task::{ContextId, Task, TaskId, TaskState};
+
+// ── TaskStatusUpdateEvent ─────────────────────────────────────────────────────
+
+/// A streaming event that reports a change in task state.
+///
+/// The `r#final` field uses the raw identifier syntax because `final` is a
+/// reserved keyword in Rust; it serializes as `"final"` in JSON.
+///
+/// The wire `kind` field (`"status-update"`) is injected by the enclosing
+/// [`StreamResponse`] discriminated union.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskStatusUpdateEvent {
+    /// The task whose status changed.
+    pub task_id: TaskId,
+
+    /// Conversation context the task belongs to.
+    pub context_id: ContextId,
+
+    /// New task state.
+    pub state: TaskState,
+
+    /// Optional agent message accompanying this status change.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<Message>,
+
+    /// Arbitrary metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+
+    /// Whether this is the last event for this task stream.
+    ///
+    /// Uses the raw identifier `r#final` because `final` is a Rust keyword.
+    #[serde(rename = "final")]
+    pub r#final: bool,
+}
+
+// ── TaskArtifactUpdateEvent ───────────────────────────────────────────────────
+
+/// A streaming event that delivers a new or updated artifact.
+///
+/// The wire `kind` field (`"artifact-update"`) is injected by the enclosing
+/// [`StreamResponse`] discriminated union.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskArtifactUpdateEvent {
+    /// The task that produced the artifact.
+    pub task_id: TaskId,
+
+    /// Conversation context the task belongs to.
+    pub context_id: ContextId,
+
+    /// The artifact being delivered.
+    pub artifact: Artifact,
+
+    /// If `true`, this event's artifact parts should be appended to the
+    /// previously-received artifact with the same ID rather than replacing it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub append: Option<bool>,
+
+    /// If `true`, this is the final chunk for the artifact.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_chunk: Option<bool>,
+
+    /// Arbitrary metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+// ── StreamResponse ────────────────────────────────────────────────────────────
+
+/// A single event payload in an A2A streaming response.
+///
+/// Discriminated on the `"kind"` field. Clients receive these events via
+/// Server-Sent Events (SSE).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum StreamResponse {
+    /// A complete task object (initial response before streaming begins).
+    Task(Task),
+
+    /// A complete message (returned synchronously for short responses).
+    Message(Message),
+
+    /// A task state change event.
+    #[serde(rename = "status-update")]
+    StatusUpdate(TaskStatusUpdateEvent),
+
+    /// An artifact delivery event.
+    #[serde(rename = "artifact-update")]
+    ArtifactUpdate(TaskArtifactUpdateEvent),
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::artifact::ArtifactId;
+    use crate::message::{Part, TextPart};
+    use crate::task::TaskStatus;
+
+    #[test]
+    fn status_update_event_roundtrip() {
+        let event = TaskStatusUpdateEvent {
+            task_id: TaskId::new("task-1"),
+            context_id: ContextId::new("ctx-1"),
+            state: TaskState::Completed,
+            message: None,
+            metadata: None,
+            r#final: true,
+        };
+        let json = serde_json::to_string(&event).expect("serialize");
+        assert!(json.contains("\"final\":true"), "final field: {json}");
+
+        let back: TaskStatusUpdateEvent = serde_json::from_str(&json).expect("deserialize");
+        assert!(back.r#final);
+        assert_eq!(back.state, TaskState::Completed);
+    }
+
+    #[test]
+    fn artifact_update_event_roundtrip() {
+        let event = TaskArtifactUpdateEvent {
+            task_id: TaskId::new("task-1"),
+            context_id: ContextId::new("ctx-1"),
+            artifact: Artifact::new(
+                ArtifactId::new("art-1"),
+                vec![Part::Text(TextPart::new("output"))],
+            ),
+            append: Some(false),
+            last_chunk: Some(true),
+            metadata: None,
+        };
+        let json = serde_json::to_string(&event).expect("serialize");
+        let back: TaskArtifactUpdateEvent = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.last_chunk, Some(true));
+    }
+
+    #[test]
+    fn stream_response_task_variant() {
+        let task = Task {
+            id: TaskId::new("t1"),
+            context_id: ContextId::new("c1"),
+            status: TaskStatus::new(TaskState::Working),
+            history: None,
+            artifacts: None,
+            metadata: None,
+        };
+        let resp = StreamResponse::Task(task);
+        let json = serde_json::to_string(&resp).expect("serialize");
+        // StreamResponse::Task adds kind="task" via the outer enum tag
+        assert!(
+            json.contains("\"kind\":\"task\""),
+            "expected task kind: {json}"
+        );
+
+        let back: StreamResponse = serde_json::from_str(&json).expect("deserialize");
+        assert!(matches!(back, StreamResponse::Task(_)));
+    }
+
+    #[test]
+    fn stream_response_status_update_variant() {
+        let event = TaskStatusUpdateEvent {
+            task_id: TaskId::new("t1"),
+            context_id: ContextId::new("c1"),
+            state: TaskState::Failed,
+            message: None,
+            metadata: None,
+            r#final: true,
+        };
+        let resp = StreamResponse::StatusUpdate(event);
+        let json = serde_json::to_string(&resp).expect("serialize");
+        assert!(
+            json.contains("\"kind\":\"status-update\""),
+            "expected status-update kind: {json}"
+        );
+
+        let back: StreamResponse = serde_json::from_str(&json).expect("deserialize");
+        assert!(matches!(back, StreamResponse::StatusUpdate(_)));
+    }
+}

--- a/crates/a2a-types/src/extensions.rs
+++ b/crates/a2a-types/src/extensions.rs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Tom F.
+
+//! Agent extension and card-signature types.
+//!
+//! Extensions allow agents to advertise optional capabilities beyond the core
+//! A2A 0.3.0 specification. [`AgentExtension`] is referenced by
+//! [`crate::agent_card::AgentCapabilities`].
+
+use serde::{Deserialize, Serialize};
+
+// ── AgentExtension ────────────────────────────────────────────────────────────
+
+/// Describes an optional extension that an agent supports.
+///
+/// Extensions are identified by a URI and may carry an arbitrary JSON
+/// parameter block understood by the extension spec.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentExtension {
+    /// Unique URI identifying the extension (e.g. `"https://example.com/ext/v1"`).
+    pub uri: String,
+
+    /// Human-readable description of the extension's purpose.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Whether clients **must** support this extension to interact correctly.
+    ///
+    /// A value of `true` means the agent cannot operate meaningfully without
+    /// the client understanding this extension.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required: Option<bool>,
+
+    /// Extension-specific parameters; structure is defined by the extension URI.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<serde_json::Value>,
+}
+
+impl AgentExtension {
+    /// Creates a minimal [`AgentExtension`] with only a URI.
+    #[must_use]
+    pub fn new(uri: impl Into<String>) -> Self {
+        Self {
+            uri: uri.into(),
+            description: None,
+            required: None,
+            params: None,
+        }
+    }
+}
+
+// ── AgentCardSignature ────────────────────────────────────────────────────────
+
+/// A cryptographic signature over an [`crate::agent_card::AgentCard`].
+///
+/// The exact schema for this type is an extension point in A2A 0.3.0 and is
+/// expected to be defined by a future signature specification. The raw
+/// [`serde_json::Value`] representation is used until the schema is finalised.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentCardSignature(
+    /// Raw JSON object carrying the signature fields.
+    pub serde_json::Value,
+);
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_extension_minimal_roundtrip() {
+        let ext = AgentExtension::new("https://example.com/ext/v1");
+        let json = serde_json::to_string(&ext).expect("serialize");
+        assert!(json.contains("\"uri\""));
+        assert!(
+            !json.contains("\"description\""),
+            "None fields must be omitted"
+        );
+
+        let back: AgentExtension = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.uri, "https://example.com/ext/v1");
+    }
+
+    #[test]
+    fn agent_extension_full_roundtrip() {
+        let mut ext = AgentExtension::new("https://example.com/ext/v1");
+        ext.description = Some("Cool extension".into());
+        ext.required = Some(true);
+        ext.params = Some(serde_json::json!({"version": 2}));
+
+        let json = serde_json::to_string(&ext).expect("serialize");
+        let back: AgentExtension = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(back.description.as_deref(), Some("Cool extension"));
+        assert_eq!(back.required, Some(true));
+    }
+}

--- a/crates/a2a-types/src/jsonrpc.rs
+++ b/crates/a2a-types/src/jsonrpc.rs
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Tom F.
+
+//! JSON-RPC 2.0 envelope types.
+//!
+//! A2A 0.3.0 uses JSON-RPC 2.0 as its wire protocol. This module provides the
+//! request/response envelope types. Protocol-method-specific parameter and
+//! result types live in [`crate::params`] and the individual domain modules.
+//!
+//! # Key types
+//!
+//! - [`JsonRpcRequest`] — outbound method call.
+//! - [`JsonRpcResponse`] — inbound response (success **or** error, untagged union).
+//! - [`JsonRpcError`] — structured error object carried in error responses.
+//! - [`JsonRpcVersion`] — newtype that always serializes/deserializes as `"2.0"`.
+
+use std::fmt;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+// ── JsonRpcVersion ────────────────────────────────────────────────────────────
+
+/// The JSON-RPC protocol version marker.
+///
+/// Always serializes as the string `"2.0"`. Deserialization rejects any value
+/// other than `"2.0"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct JsonRpcVersion;
+
+impl Default for JsonRpcVersion {
+    fn default() -> Self {
+        Self
+    }
+}
+
+impl fmt::Display for JsonRpcVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("2.0")
+    }
+}
+
+impl Serialize for JsonRpcVersion {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str("2.0")
+    }
+}
+
+impl<'de> Deserialize<'de> for JsonRpcVersion {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        if s == "2.0" {
+            Ok(Self)
+        } else {
+            Err(serde::de::Error::custom(format!(
+                "expected JSON-RPC version \"2.0\", got \"{s}\""
+            )))
+        }
+    }
+}
+
+// ── JsonRpcId ─────────────────────────────────────────────────────────────────
+
+/// A JSON-RPC 2.0 request/response identifier.
+///
+/// Per spec, valid values are a string, a number, or `null`. When the field is
+/// absent entirely (notifications), represent as `None`.
+pub type JsonRpcId = Option<serde_json::Value>;
+
+// ── JsonRpcRequest ────────────────────────────────────────────────────────────
+
+/// A JSON-RPC 2.0 request object.
+///
+/// When `id` is `None`, the request is a *notification* and no response is
+/// expected.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcRequest {
+    /// Protocol version — always `"2.0"`.
+    pub jsonrpc: JsonRpcVersion,
+
+    /// Request identifier; `None` for notifications.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: JsonRpcId,
+
+    /// A2A method name (e.g. `"message/send"`).
+    pub method: String,
+
+    /// Method-specific parameters.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<serde_json::Value>,
+}
+
+impl JsonRpcRequest {
+    /// Creates a new request with the given `id` and `method`.
+    #[must_use]
+    pub fn new(id: serde_json::Value, method: impl Into<String>) -> Self {
+        Self {
+            jsonrpc: JsonRpcVersion,
+            id: Some(id),
+            method: method.into(),
+            params: None,
+        }
+    }
+
+    /// Creates a new request with `params`.
+    #[must_use]
+    pub fn with_params(
+        id: serde_json::Value,
+        method: impl Into<String>,
+        params: serde_json::Value,
+    ) -> Self {
+        Self {
+            jsonrpc: JsonRpcVersion,
+            id: Some(id),
+            method: method.into(),
+            params: Some(params),
+        }
+    }
+
+    /// Creates a notification (no `id`, no response expected).
+    #[must_use]
+    pub fn notification(method: impl Into<String>, params: Option<serde_json::Value>) -> Self {
+        Self {
+            jsonrpc: JsonRpcVersion,
+            id: None,
+            method: method.into(),
+            params,
+        }
+    }
+}
+
+// ── JsonRpcResponse ───────────────────────────────────────────────────────────
+
+/// A JSON-RPC 2.0 response: either a success with a `result` or an error with
+/// an `error` object.
+///
+/// The `untagged` representation tries `Success` first; if `result` is absent
+/// it falls back to `Error`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum JsonRpcResponse<T> {
+    /// Successful response carrying a typed result.
+    Success(JsonRpcSuccessResponse<T>),
+    /// Error response carrying a structured error object.
+    Error(JsonRpcErrorResponse),
+}
+
+// ── JsonRpcSuccessResponse ────────────────────────────────────────────────────
+
+/// A successful JSON-RPC 2.0 response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcSuccessResponse<T> {
+    /// Protocol version — always `"2.0"`.
+    pub jsonrpc: JsonRpcVersion,
+
+    /// Matches the `id` of the corresponding request.
+    pub id: JsonRpcId,
+
+    /// The method result.
+    pub result: T,
+}
+
+impl<T> JsonRpcSuccessResponse<T> {
+    /// Creates a success response for the given request `id`.
+    #[must_use]
+    pub const fn new(id: JsonRpcId, result: T) -> Self {
+        Self {
+            jsonrpc: JsonRpcVersion,
+            id,
+            result,
+        }
+    }
+}
+
+// ── JsonRpcErrorResponse ──────────────────────────────────────────────────────
+
+/// An error JSON-RPC 2.0 response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcErrorResponse {
+    /// Protocol version — always `"2.0"`.
+    pub jsonrpc: JsonRpcVersion,
+
+    /// Matches the `id` of the corresponding request, or `null` if the id
+    /// could not be determined.
+    pub id: JsonRpcId,
+
+    /// Structured error object.
+    pub error: JsonRpcError,
+}
+
+impl JsonRpcErrorResponse {
+    /// Creates an error response for the given request `id`.
+    #[must_use]
+    pub const fn new(id: JsonRpcId, error: JsonRpcError) -> Self {
+        Self {
+            jsonrpc: JsonRpcVersion,
+            id,
+            error,
+        }
+    }
+}
+
+// ── JsonRpcError ──────────────────────────────────────────────────────────────
+
+/// The error object within a JSON-RPC 2.0 error response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcError {
+    /// Numeric error code.
+    pub code: i32,
+
+    /// Short human-readable error message.
+    pub message: String,
+
+    /// Optional additional error details.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+impl JsonRpcError {
+    /// Creates a new error object.
+    #[must_use]
+    pub fn new(code: i32, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            data: None,
+        }
+    }
+
+    /// Creates a new error object with additional data.
+    #[must_use]
+    pub fn with_data(code: i32, message: impl Into<String>, data: serde_json::Value) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            data: Some(data),
+        }
+    }
+}
+
+impl fmt::Display for JsonRpcError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}] {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for JsonRpcError {}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_serializes_as_2_0() {
+        let v = JsonRpcVersion;
+        let s = serde_json::to_string(&v).expect("serialize");
+        assert_eq!(s, "\"2.0\"");
+    }
+
+    #[test]
+    fn version_rejects_wrong_version() {
+        let result: Result<JsonRpcVersion, _> = serde_json::from_str("\"1.0\"");
+        assert!(result.is_err(), "should reject non-2.0 version");
+    }
+
+    #[test]
+    fn version_accepts_2_0() {
+        let v: JsonRpcVersion = serde_json::from_str("\"2.0\"").expect("deserialize");
+        assert_eq!(v, JsonRpcVersion);
+    }
+
+    #[test]
+    fn request_roundtrip() {
+        let req = JsonRpcRequest::with_params(
+            serde_json::json!(1),
+            "message/send",
+            serde_json::json!({"message": {}}),
+        );
+        let json = serde_json::to_string(&req).expect("serialize");
+        assert!(json.contains("\"jsonrpc\":\"2.0\""));
+        assert!(json.contains("\"method\":\"message/send\""));
+
+        let back: JsonRpcRequest = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.method, "message/send");
+    }
+
+    #[test]
+    fn success_response_roundtrip() {
+        let resp: JsonRpcResponse<serde_json::Value> =
+            JsonRpcResponse::Success(JsonRpcSuccessResponse::new(
+                Some(serde_json::json!(42)),
+                serde_json::json!({"status": "ok"}),
+            ));
+        let json = serde_json::to_string(&resp).expect("serialize");
+        assert!(json.contains("\"result\""));
+        assert!(!json.contains("\"error\""));
+    }
+
+    #[test]
+    fn error_response_roundtrip() {
+        let resp: JsonRpcResponse<serde_json::Value> =
+            JsonRpcResponse::Error(JsonRpcErrorResponse::new(
+                Some(serde_json::json!(1)),
+                JsonRpcError::new(-32601, "Method not found"),
+            ));
+        let json = serde_json::to_string(&resp).expect("serialize");
+        assert!(json.contains("\"error\""));
+        assert!(json.contains("-32601"));
+    }
+
+    #[test]
+    fn notification_has_no_id() {
+        let n = JsonRpcRequest::notification("task/cancel", None);
+        let json = serde_json::to_string(&n).expect("serialize");
+        assert!(
+            !json.contains("\"id\""),
+            "notification must omit id: {json}"
+        );
+    }
+}

--- a/crates/a2a-types/src/lib.rs
+++ b/crates/a2a-types/src/lib.rs
@@ -5,8 +5,69 @@
 //!
 //! This crate provides all wire types for the A2A protocol with zero I/O
 //! dependencies. Add `a2a-client` or `a2a-server` for HTTP transport.
+//!
+//! # Module overview
+//!
+//! | Module | Contents |
+//! |---|---|
+//! | [`error`] | [`error::A2aError`], [`error::ErrorCode`], [`error::A2aResult`] |
+//! | [`task`] | [`task::Task`], [`task::TaskStatus`], [`task::TaskState`], ID newtypes |
+//! | [`message`] | [`message::Message`], [`message::Part`], file/text/data parts |
+//! | [`artifact`] | [`artifact::Artifact`], [`artifact::ArtifactId`] |
+//! | [`agent_card`] | [`agent_card::AgentCard`], capabilities, skills |
+//! | [`security`] | [`security::SecurityScheme`] variants, OAuth flows |
+//! | [`events`] | [`events::StreamResponse`], status/artifact update events |
+//! | [`jsonrpc`] | [`jsonrpc::JsonRpcRequest`], [`jsonrpc::JsonRpcResponse`] |
+//! | [`params`] | Method parameter structs |
+//! | [`push`] | [`push::PushNotificationConfig`] |
+//! | [`extensions`] | [`extensions::AgentExtension`], [`extensions::AgentCardSignature`] |
+//! | [`responses`] | [`responses::SendMessageResponse`], [`responses::TaskListResponse`] |
 
 #![warn(missing_docs)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![warn(clippy::all, clippy::pedantic, clippy::nursery)]
 #![allow(clippy::module_name_repetitions)]
+
+pub mod agent_card;
+pub mod artifact;
+pub mod error;
+pub mod events;
+pub mod extensions;
+pub mod jsonrpc;
+pub mod message;
+pub mod params;
+pub mod push;
+pub mod responses;
+pub mod security;
+pub mod task;
+
+// ── Flat re-exports ───────────────────────────────────────────────────────────
+
+pub use agent_card::{
+    AgentCapabilities, AgentCard, AgentInterface, AgentProvider, AgentSkill, TransportProtocol,
+};
+pub use artifact::{Artifact, ArtifactId};
+pub use error::{A2aError, A2aResult, ErrorCode};
+pub use events::{StreamResponse, TaskArtifactUpdateEvent, TaskStatusUpdateEvent};
+pub use extensions::{AgentCardSignature, AgentExtension};
+pub use jsonrpc::{
+    JsonRpcError, JsonRpcErrorResponse, JsonRpcId, JsonRpcRequest, JsonRpcResponse,
+    JsonRpcSuccessResponse, JsonRpcVersion,
+};
+pub use message::{
+    DataPart, FileContent, FilePart, FileWithBytes, FileWithUri, Message, MessageId, MessageRole,
+    Part, TextPart,
+};
+pub use params::{
+    DeletePushConfigParams, GetPushConfigParams, ListTasksParams, MessageSendParams,
+    SendMessageConfiguration, TaskIdParams, TaskQueryParams,
+};
+pub use push::{PushNotificationAuthInfo, PushNotificationConfig, TaskPushNotificationConfig};
+pub use responses::{AuthenticatedExtendedCardResponse, SendMessageResponse, TaskListResponse};
+pub use security::{
+    ApiKeyLocation, ApiKeySecurityScheme, AuthorizationCodeFlow, ClientCredentialsFlow,
+    DeviceCodeFlow, HttpAuthSecurityScheme, ImplicitFlow, MutualTlsSecurityScheme,
+    NamedSecuritySchemes, OAuth2SecurityScheme, OAuthFlows, OpenIdConnectSecurityScheme,
+    SecurityRequirements, SecurityScheme,
+};
+pub use task::{ContextId, Task, TaskId, TaskState, TaskStatus, TaskVersion};

--- a/crates/a2a-types/src/message.rs
+++ b/crates/a2a-types/src/message.rs
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Tom F.
+
+//! Message types for the A2A protocol.
+//!
+//! A [`Message`] is the fundamental communication unit between a client and an
+//! agent. Each message has a [`MessageRole`] (`user` or `agent`) and carries
+//! one or more [`Part`] values (text, file, or structured data).
+//!
+//! # Part discriminated union
+//!
+//! [`Part`] uses `#[serde(tag = "kind")]` so that `{"kind":"text","text":"hi"}`
+//! deserializes to `Part::Text(TextPart { text: "hi", .. })`.
+//!
+//! # File content
+//!
+//! [`FileContent`] is an untagged union: if the JSON object has a `bytes` field
+//! it deserializes as [`FileWithBytes`]; if it has a `uri` field it deserializes
+//! as [`FileWithUri`].
+
+use serde::{Deserialize, Serialize};
+
+use crate::task::{ContextId, TaskId};
+
+// ── MessageId ─────────────────────────────────────────────────────────────────
+
+/// Opaque unique identifier for a [`Message`].
+///
+/// Wraps a `String` for compile-time type safety — a [`MessageId`] cannot be
+/// accidentally passed where a [`TaskId`] is expected.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct MessageId(pub String);
+
+impl MessageId {
+    /// Creates a new [`MessageId`] from any string-like value.
+    #[must_use]
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+}
+
+impl std::fmt::Display for MessageId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for MessageId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for MessageId {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
+impl AsRef<str> for MessageId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+// ── MessageRole ───────────────────────────────────────────────────────────────
+
+/// The originator of a [`Message`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MessageRole {
+    /// Sent by the human/client side.
+    User,
+    /// Sent by the agent.
+    Agent,
+}
+
+// ── Message ───────────────────────────────────────────────────────────────────
+
+/// A message exchanged between a client and an agent.
+///
+/// The wire `kind` field (`"message"`) is injected by enclosing discriminated
+/// unions such as [`crate::events::StreamResponse`] and
+/// [`crate::responses::SendMessageResponse`]. Standalone `Message` values
+/// received over the wire may include `kind`; serde silently tolerates unknown
+/// fields, so no action is needed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Message {
+    /// Unique message identifier.
+    #[serde(rename = "messageId")]
+    pub id: MessageId,
+
+    /// Role of the message originator.
+    pub role: MessageRole,
+
+    /// Message content parts (must contain at least one element).
+    pub parts: Vec<Part>,
+
+    /// Task this message belongs to, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<TaskId>,
+
+    /// Conversation context this message belongs to, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<ContextId>,
+
+    /// IDs of tasks referenced by this message.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reference_task_ids: Option<Vec<TaskId>>,
+
+    /// URIs of extensions used in this message.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<Vec<String>>,
+
+    /// Arbitrary metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+// ── Part ─────────────────────────────────────────────────────────────────────
+
+/// A content part within a [`Message`] or [`crate::artifact::Artifact`].
+///
+/// Discriminated by the `"kind"` field: `"text"`, `"file"`, or `"data"`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum Part {
+    /// Plain-text content.
+    Text(TextPart),
+    /// File content (bytes or URI reference).
+    File(FilePart),
+    /// Structured JSON data.
+    Data(DataPart),
+}
+
+// ── TextPart ──────────────────────────────────────────────────────────────────
+
+/// A plain-text message part.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TextPart {
+    /// The text content.
+    pub text: String,
+
+    /// Arbitrary metadata for this part.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+impl TextPart {
+    /// Creates a [`TextPart`] with the given text and no metadata.
+    #[must_use]
+    pub fn new(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            metadata: None,
+        }
+    }
+}
+
+// ── FilePart ──────────────────────────────────────────────────────────────────
+
+/// A file message part, carrying either inline bytes or a URI reference.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FilePart {
+    /// The file content (inline bytes or URI).
+    pub file: FileContent,
+
+    /// Arbitrary metadata for this part.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+// ── FileContent ───────────────────────────────────────────────────────────────
+
+/// File content: either inline base64-encoded bytes or a URI reference.
+///
+/// This is an untagged union. Serde tries [`FileWithBytes`] first (matches when
+/// a `bytes` field is present), then [`FileWithUri`] (matches when a `uri`
+/// field is present).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum FileContent {
+    /// File data encoded as a base64 string in the `bytes` field.
+    Bytes(FileWithBytes),
+    /// File accessible via a URI.
+    Uri(FileWithUri),
+}
+
+// ── FileWithBytes ─────────────────────────────────────────────────────────────
+
+/// Inline file content: base64-encoded bytes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileWithBytes {
+    /// Optional file name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    /// MIME type of the file (e.g. `"image/png"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+
+    /// Base64-encoded file content.
+    pub bytes: String,
+}
+
+// ── FileWithUri ───────────────────────────────────────────────────────────────
+
+/// File content accessible via a URI.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileWithUri {
+    /// Optional file name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    /// MIME type of the file (e.g. `"application/pdf"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+
+    /// Absolute URI of the file.
+    pub uri: String,
+}
+
+// ── DataPart ──────────────────────────────────────────────────────────────────
+
+/// A structured-data message part carrying an arbitrary JSON object.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DataPart {
+    /// Structured JSON payload (should be an object per spec).
+    pub data: serde_json::Value,
+
+    /// Arbitrary metadata for this part.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_message() -> Message {
+        Message {
+            id: MessageId::new("msg-1"),
+            role: MessageRole::User,
+            parts: vec![Part::Text(TextPart::new("Hello"))],
+            task_id: None,
+            context_id: None,
+            reference_task_ids: None,
+            extensions: None,
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn message_roundtrip() {
+        let msg = make_message();
+        let json = serde_json::to_string(&msg).expect("serialize");
+        assert!(json.contains("\"messageId\":\"msg-1\""));
+        assert!(json.contains("\"role\":\"user\""));
+
+        let back: Message = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.id, MessageId::new("msg-1"));
+        assert_eq!(back.role, MessageRole::User);
+    }
+
+    #[test]
+    fn text_part_roundtrip() {
+        let part = Part::Text(TextPart::new("hello world"));
+        let json = serde_json::to_string(&part).expect("serialize");
+        assert!(json.contains("\"kind\":\"text\""));
+        assert!(json.contains("\"text\":\"hello world\""));
+        let back: Part = serde_json::from_str(&json).expect("deserialize");
+        assert!(matches!(back, Part::Text(_)));
+    }
+
+    #[test]
+    fn file_part_bytes_roundtrip() {
+        let part = Part::File(FilePart {
+            file: FileContent::Bytes(FileWithBytes {
+                name: Some("test.png".into()),
+                mime_type: Some("image/png".into()),
+                bytes: "aGVsbG8=".into(),
+            }),
+            metadata: None,
+        });
+        let json = serde_json::to_string(&part).expect("serialize");
+        assert!(json.contains("\"bytes\""));
+        let back: Part = serde_json::from_str(&json).expect("deserialize");
+        assert!(matches!(back, Part::File(_)));
+    }
+
+    #[test]
+    fn file_part_uri_roundtrip() {
+        let part = Part::File(FilePart {
+            file: FileContent::Uri(FileWithUri {
+                name: None,
+                mime_type: None,
+                uri: "https://example.com/file.pdf".into(),
+            }),
+            metadata: None,
+        });
+        let json = serde_json::to_string(&part).expect("serialize");
+        assert!(json.contains("\"uri\""));
+        let back: Part = serde_json::from_str(&json).expect("deserialize");
+        assert!(matches!(back, Part::File(_)));
+    }
+
+    #[test]
+    fn data_part_roundtrip() {
+        let part = Part::Data(DataPart {
+            data: serde_json::json!({"key": "value"}),
+            metadata: None,
+        });
+        let json = serde_json::to_string(&part).expect("serialize");
+        assert!(json.contains("\"kind\":\"data\""));
+        let back: Part = serde_json::from_str(&json).expect("deserialize");
+        assert!(matches!(back, Part::Data(_)));
+    }
+
+    #[test]
+    fn none_fields_omitted() {
+        let msg = make_message();
+        let json = serde_json::to_string(&msg).expect("serialize");
+        assert!(
+            !json.contains("\"taskId\""),
+            "taskId should be omitted: {json}"
+        );
+        assert!(
+            !json.contains("\"metadata\""),
+            "metadata should be omitted: {json}"
+        );
+    }
+}

--- a/crates/a2a-types/src/params.rs
+++ b/crates/a2a-types/src/params.rs
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Tom F.
+
+//! JSON-RPC method parameter types.
+//!
+//! Each A2A 0.3.0 method has a corresponding `Params` struct that maps to the
+//! `params` field of a [`crate::jsonrpc::JsonRpcRequest`].
+//!
+//! | Method | Params type |
+//! |---|---|
+//! | `message/send` | [`MessageSendParams`] |
+//! | `message/stream` | [`MessageSendParams`] |
+//! | `tasks/get` | [`TaskQueryParams`] |
+//! | `tasks/cancel` | [`TaskIdParams`] |
+//! | `tasks/list` | [`ListTasksParams`] |
+//! | `tasks/resubscribe` | [`TaskIdParams`] |
+//! | `tasks/pushNotificationConfig/set` | [`crate::push::TaskPushNotificationConfig`] |
+//! | `tasks/pushNotificationConfig/get` | [`GetPushConfigParams`] |
+//! | `tasks/pushNotificationConfig/delete` | [`DeletePushConfigParams`] |
+
+use serde::{Deserialize, Serialize};
+
+use crate::message::Message;
+use crate::push::TaskPushNotificationConfig;
+use crate::task::{ContextId, TaskId, TaskState};
+
+// ── SendMessageConfiguration ──────────────────────────────────────────────────
+
+/// Optional configuration for a `message/send` or `message/stream` call.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SendMessageConfiguration {
+    /// MIME types the client can accept as output (e.g. `["text/plain"]`).
+    pub accepted_output_modes: Vec<String>,
+
+    /// Push notification config to register alongside this message send.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_push_notification_config: Option<TaskPushNotificationConfig>,
+
+    /// Number of historical messages to include in the response.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub history_length: Option<u32>,
+
+    /// If `true`, return immediately with the task object rather than waiting
+    /// for completion.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub return_immediately: Option<bool>,
+}
+
+// ── MessageSendParams ─────────────────────────────────────────────────────────
+
+/// Parameters for the `message/send` and `message/stream` methods.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageSendParams {
+    /// The message to send to the agent.
+    pub message: Message,
+
+    /// Optional send configuration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub configuration: Option<SendMessageConfiguration>,
+
+    /// Arbitrary caller metadata attached to the request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+// ── TaskQueryParams ───────────────────────────────────────────────────────────
+
+/// Parameters for the `tasks/get` method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskQueryParams {
+    /// ID of the task to retrieve.
+    pub id: TaskId,
+
+    /// Number of historical messages to include in the response.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub history_length: Option<u32>,
+}
+
+// ── TaskIdParams ──────────────────────────────────────────────────────────────
+
+/// Minimal parameters identifying a single task by ID.
+///
+/// Used for `tasks/cancel` and `tasks/resubscribe`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskIdParams {
+    /// ID of the target task.
+    pub id: TaskId,
+}
+
+// ── ListTasksParams ───────────────────────────────────────────────────────────
+
+/// Parameters for the `tasks/list` method.
+///
+/// All fields are optional filters; omitting them returns all tasks visible to
+/// the caller (subject to the server's default page size).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListTasksParams {
+    /// Filter to tasks belonging to this conversation context.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<ContextId>,
+
+    /// Filter to tasks in this state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<TaskState>,
+
+    /// Maximum number of tasks to return per page (1–100, default 50).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_size: Option<u32>,
+
+    /// Pagination cursor returned by the previous response.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_token: Option<String>,
+
+    /// Return only tasks whose status changed after this ISO 8601 timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_timestamp_after: Option<String>,
+
+    /// If `true`, include artifact data in the returned tasks.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_artifacts: Option<bool>,
+}
+
+// ── GetPushConfigParams ───────────────────────────────────────────────────────
+
+/// Parameters for the `tasks/pushNotificationConfig/get` method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetPushConfigParams {
+    /// The task whose push config to retrieve.
+    pub task_id: TaskId,
+
+    /// The server-assigned push config identifier.
+    pub id: String,
+}
+
+// ── DeletePushConfigParams ────────────────────────────────────────────────────
+
+/// Parameters for the `tasks/pushNotificationConfig/delete` method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeletePushConfigParams {
+    /// The task whose push config to delete.
+    pub task_id: TaskId,
+
+    /// The server-assigned push config identifier.
+    pub id: String,
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::{MessageId, MessageRole, Part, TextPart};
+
+    fn make_message() -> Message {
+        Message {
+            id: MessageId::new("msg-1"),
+            role: MessageRole::User,
+            parts: vec![Part::Text(TextPart::new("hello"))],
+            task_id: None,
+            context_id: None,
+            reference_task_ids: None,
+            extensions: None,
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn message_send_params_roundtrip() {
+        let params = MessageSendParams {
+            message: make_message(),
+            configuration: Some(SendMessageConfiguration {
+                accepted_output_modes: vec!["text/plain".into()],
+                task_push_notification_config: None,
+                history_length: Some(10),
+                return_immediately: None,
+            }),
+            metadata: None,
+        };
+        let json = serde_json::to_string(&params).expect("serialize");
+        let back: MessageSendParams = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.message.id, MessageId::new("msg-1"));
+    }
+
+    #[test]
+    fn list_tasks_params_empty_roundtrip() {
+        let params = ListTasksParams {
+            context_id: None,
+            status: None,
+            page_size: None,
+            page_token: None,
+            status_timestamp_after: None,
+            include_artifacts: None,
+        };
+        let json = serde_json::to_string(&params).expect("serialize");
+        // All optional fields should be absent
+        assert_eq!(json, "{}", "empty params should serialize to {{}}");
+    }
+
+    #[test]
+    fn task_query_params_roundtrip() {
+        let params = TaskQueryParams {
+            id: TaskId::new("task-1"),
+            history_length: Some(5),
+        };
+        let json = serde_json::to_string(&params).expect("serialize");
+        let back: TaskQueryParams = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.id, TaskId::new("task-1"));
+        assert_eq!(back.history_length, Some(5));
+    }
+}

--- a/crates/a2a-types/src/push.rs
+++ b/crates/a2a-types/src/push.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Tom F.
+
+//! Push notification configuration types.
+//!
+//! Push notifications allow an agent to deliver task updates to a client-owned
+//! HTTPS webhook endpoint rather than requiring the client to poll. A client
+//! registers a [`PushNotificationConfig`] for a specific task via the
+//! `tasks/pushNotificationConfig/set` method.
+
+use serde::{Deserialize, Serialize};
+
+use crate::task::TaskId;
+
+// ── PushNotificationAuthInfo ──────────────────────────────────────────────────
+
+/// Authentication information used by an agent when calling a push webhook.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PushNotificationAuthInfo {
+    /// Supported authentication schemes (e.g. `["bearer"]`).
+    pub schemes: Vec<String>,
+
+    /// Optional pre-shared credential value (e.g. a static token).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credentials: Option<String>,
+}
+
+// ── PushNotificationConfig ────────────────────────────────────────────────────
+
+/// Configuration for delivering task updates to a webhook endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PushNotificationConfig {
+    /// Server-assigned configuration identifier.
+    ///
+    /// Absent when first creating the config; populated in the server response.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// HTTPS URL of the client's webhook endpoint.
+    pub url: String,
+
+    /// Optional shared secret for request verification (HMAC or similar).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+
+    /// Authentication details the agent should use when calling the webhook.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authentication: Option<PushNotificationAuthInfo>,
+}
+
+impl PushNotificationConfig {
+    /// Creates a minimal [`PushNotificationConfig`] with only a URL.
+    #[must_use]
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            id: None,
+            url: url.into(),
+            token: None,
+            authentication: None,
+        }
+    }
+}
+
+// ── TaskPushNotificationConfig ────────────────────────────────────────────────
+
+/// Associates a [`PushNotificationConfig`] with a specific task.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskPushNotificationConfig {
+    /// The task for which push notifications are configured.
+    pub task_id: TaskId,
+
+    /// The push notification configuration.
+    pub push_notification_config: PushNotificationConfig,
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_config_minimal_roundtrip() {
+        let cfg = PushNotificationConfig::new("https://example.com/webhook");
+        let json = serde_json::to_string(&cfg).expect("serialize");
+        assert!(json.contains("\"url\""));
+        assert!(!json.contains("\"id\""), "id should be omitted when None");
+
+        let back: PushNotificationConfig = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.url, "https://example.com/webhook");
+    }
+
+    #[test]
+    fn task_push_config_roundtrip() {
+        let cfg = TaskPushNotificationConfig {
+            task_id: TaskId::new("task-1"),
+            push_notification_config: PushNotificationConfig {
+                id: Some("cfg-1".into()),
+                url: "https://example.com/webhook".into(),
+                token: Some("secret".into()),
+                authentication: Some(PushNotificationAuthInfo {
+                    schemes: vec!["bearer".into()],
+                    credentials: None,
+                }),
+            },
+        };
+        let json = serde_json::to_string(&cfg).expect("serialize");
+        let back: TaskPushNotificationConfig = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.task_id, TaskId::new("task-1"));
+        assert_eq!(
+            back.push_notification_config.url,
+            "https://example.com/webhook"
+        );
+    }
+}

--- a/crates/a2a-types/src/responses.rs
+++ b/crates/a2a-types/src/responses.rs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Tom F.
+
+//! RPC method response types.
+//!
+//! These types appear as the `result` field of a
+//! [`crate::jsonrpc::JsonRpcSuccessResponse`].
+//!
+//! | Method | Response type |
+//! |---|---|
+//! | `message/send` | [`SendMessageResponse`] |
+//! | `tasks/list` | [`TaskListResponse`] |
+//! | `agent/authenticatedExtendedCard` | [`AgentCard`] (re-exported as [`AuthenticatedExtendedCardResponse`]) |
+
+use serde::{Deserialize, Serialize};
+
+use crate::agent_card::AgentCard;
+use crate::message::Message;
+use crate::task::Task;
+
+// ── SendMessageResponse ───────────────────────────────────────────────────────
+
+/// The result of a `message/send` call: either a completed [`Task`] or an
+/// immediate [`Message`] response.
+///
+/// Discriminated on the `"kind"` field: `"task"` or `"message"`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum SendMessageResponse {
+    /// The agent accepted the message and created (or updated) a task.
+    Task(Task),
+
+    /// The agent responded immediately with a message (no task created).
+    Message(Message),
+}
+
+// ── TaskListResponse ──────────────────────────────────────────────────────────
+
+/// The result of a `tasks/list` call: a page of tasks with an optional
+/// continuation token.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskListResponse {
+    /// The tasks in this page of results.
+    pub tasks: Vec<Task>,
+
+    /// Pagination token for the next page; absent on the last page.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_page_token: Option<String>,
+}
+
+impl TaskListResponse {
+    /// Creates a single-page response with no next-page token.
+    #[must_use]
+    pub const fn new(tasks: Vec<Task>) -> Self {
+        Self {
+            tasks,
+            next_page_token: None,
+        }
+    }
+}
+
+// ── AuthenticatedExtendedCardResponse ─────────────────────────────────────────
+
+/// The full (private) agent card returned by `agent/authenticatedExtendedCard`.
+///
+/// This is structurally identical to the public [`AgentCard`]; the type alias
+/// signals intent and may gain additional fields in a future spec revision.
+pub type AuthenticatedExtendedCardResponse = AgentCard;
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::{MessageId, MessageRole, Part, TextPart};
+    use crate::task::{ContextId, TaskId, TaskState, TaskStatus};
+
+    fn make_task() -> Task {
+        Task {
+            id: TaskId::new("t1"),
+            context_id: ContextId::new("c1"),
+            status: TaskStatus::new(TaskState::Completed),
+            history: None,
+            artifacts: None,
+            metadata: None,
+        }
+    }
+
+    fn make_message() -> Message {
+        Message {
+            id: MessageId::new("m1"),
+            role: MessageRole::Agent,
+            parts: vec![Part::Text(TextPart::new("hi"))],
+            task_id: None,
+            context_id: None,
+            reference_task_ids: None,
+            extensions: None,
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn send_message_response_task_variant() {
+        let resp = SendMessageResponse::Task(make_task());
+        let json = serde_json::to_string(&resp).expect("serialize");
+        assert!(json.contains("\"kind\":\"task\""));
+
+        let back: SendMessageResponse = serde_json::from_str(&json).expect("deserialize");
+        assert!(matches!(back, SendMessageResponse::Task(_)));
+    }
+
+    #[test]
+    fn send_message_response_message_variant() {
+        let resp = SendMessageResponse::Message(make_message());
+        let json = serde_json::to_string(&resp).expect("serialize");
+        assert!(json.contains("\"kind\":\"message\""));
+
+        let back: SendMessageResponse = serde_json::from_str(&json).expect("deserialize");
+        assert!(matches!(back, SendMessageResponse::Message(_)));
+    }
+
+    #[test]
+    fn task_list_response_roundtrip() {
+        let resp = TaskListResponse {
+            tasks: vec![make_task()],
+            next_page_token: Some("cursor-abc".into()),
+        };
+        let json = serde_json::to_string(&resp).expect("serialize");
+        assert!(json.contains("\"nextPageToken\":\"cursor-abc\""));
+
+        let back: TaskListResponse = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.tasks.len(), 1);
+        assert_eq!(back.next_page_token.as_deref(), Some("cursor-abc"));
+    }
+
+    #[test]
+    fn task_list_response_no_token_omitted() {
+        let resp = TaskListResponse::new(vec![]);
+        let json = serde_json::to_string(&resp).expect("serialize");
+        assert!(
+            !json.contains("\"nextPageToken\""),
+            "token should be absent: {json}"
+        );
+    }
+}

--- a/crates/a2a-types/src/security.rs
+++ b/crates/a2a-types/src/security.rs
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Tom F.
+
+// "OpenAPI", "OpenID", and similar proper-noun initialisms are intentionally
+// not wrapped in backticks in this module's documentation.
+#![allow(clippy::doc_markdown)]
+
+//! Security scheme types for A2A agent authentication.
+//!
+//! These types follow the security-scheme specification used by A2A 0.3.0,
+//! which is based on the OpenAPI 3.x security model.
+//! The root discriminated union is [`SecurityScheme`], tagged on the `"type"` field.
+//!
+//! `NamedSecuritySchemes` and `SecurityRequirements` are type aliases used in
+//! [`crate::agent_card::AgentCard`] and [`crate::agent_card::AgentSkill`].
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+// ── Type aliases ──────────────────────────────────────────────────────────────
+
+/// A map from security scheme name to its definition, as used in
+/// `AgentCard.securitySchemes`.
+pub type NamedSecuritySchemes = HashMap<String, SecurityScheme>;
+
+/// Security requirement list (OpenAPI style).
+///
+/// Each element of the outer `Vec` is an alternative (logical OR). Within
+/// each `HashMap`, the key is a scheme name (referencing
+/// [`NamedSecuritySchemes`]) and the value is the list of required OAuth
+/// scopes (empty for non-OAuth schemes).
+pub type SecurityRequirements = Vec<HashMap<String, Vec<String>>>;
+
+// ── SecurityScheme ────────────────────────────────────────────────────────────
+
+/// A security scheme supported by an agent, discriminated by the `"type"` field.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum SecurityScheme {
+    /// API key authentication (`"apiKey"`).
+    #[serde(rename = "apiKey")]
+    ApiKey(ApiKeySecurityScheme),
+
+    /// HTTP authentication (e.g. Bearer, Basic) (`"http"`).
+    #[serde(rename = "http")]
+    Http(HttpAuthSecurityScheme),
+
+    /// OAuth 2.0 (`"oauth2"`).
+    ///
+    /// Boxed to reduce the enum's stack size.
+    #[serde(rename = "oauth2")]
+    OAuth2(Box<OAuth2SecurityScheme>),
+
+    /// OpenID Connect (`"openIdConnect"`).
+    #[serde(rename = "openIdConnect")]
+    OpenIdConnect(OpenIdConnectSecurityScheme),
+
+    /// Mutual TLS (`"mutualTLS"`).
+    #[serde(rename = "mutualTLS")]
+    MutualTls(MutualTlsSecurityScheme),
+}
+
+// ── ApiKeySecurityScheme ──────────────────────────────────────────────────────
+
+/// API key security scheme: a token sent in a header, query parameter, or cookie.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiKeySecurityScheme {
+    /// Where the API key is transmitted.
+    ///
+    /// Serialized as `"in"` (a Rust keyword; mapped via `rename`).
+    #[serde(rename = "in")]
+    pub location: ApiKeyLocation,
+
+    /// Name of the header, query parameter, or cookie.
+    pub name: String,
+
+    /// Optional human-readable description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Where an API key is placed in the request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ApiKeyLocation {
+    /// Transmitted as an HTTP header.
+    Header,
+    /// Transmitted as a URL query parameter.
+    Query,
+    /// Transmitted as a cookie.
+    Cookie,
+}
+
+// ── HttpAuthSecurityScheme ────────────────────────────────────────────────────
+
+/// HTTP authentication security scheme (Bearer, Basic, etc.).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HttpAuthSecurityScheme {
+    /// The HTTP authentication scheme name (e.g. `"bearer"`, `"basic"`).
+    pub scheme: String,
+
+    /// Format hint for Bearer tokens (e.g. `"JWT"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bearer_format: Option<String>,
+
+    /// Optional human-readable description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+// ── OAuth2SecurityScheme ──────────────────────────────────────────────────────
+
+/// OAuth 2.0 security scheme.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OAuth2SecurityScheme {
+    /// Available OAuth 2.0 flows.
+    pub flows: OAuthFlows,
+
+    /// URL of the OAuth 2.0 server metadata document (RFC 8414).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oauth2_metadata_url: Option<String>,
+
+    /// Optional human-readable description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Available OAuth 2.0 flows for an [`OAuth2SecurityScheme`].
+///
+/// Mirrors the OpenAPI 3.x `OAuthFlows` object.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OAuthFlows {
+    /// Authorization code flow.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authorization_code: Option<AuthorizationCodeFlow>,
+
+    /// Client credentials flow.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_credentials: Option<ClientCredentialsFlow>,
+
+    /// Device authorization flow (RFC 8628).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device_code: Option<DeviceCodeFlow>,
+
+    /// Implicit flow (deprecated in OAuth 2.1 but retained for compatibility).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub implicit: Option<ImplicitFlow>,
+}
+
+/// OAuth 2.0 authorization code flow.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthorizationCodeFlow {
+    /// URL of the authorization endpoint.
+    pub authorization_url: String,
+
+    /// URL of the token endpoint.
+    pub token_url: String,
+
+    /// URL of the refresh token endpoint.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_url: Option<String>,
+
+    /// Available scopes: name → description.
+    pub scopes: HashMap<String, String>,
+}
+
+/// OAuth 2.0 client credentials flow.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientCredentialsFlow {
+    /// URL of the token endpoint.
+    pub token_url: String,
+
+    /// URL of the refresh token endpoint.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_url: Option<String>,
+
+    /// Available scopes: name → description.
+    pub scopes: HashMap<String, String>,
+}
+
+/// OAuth 2.0 device authorization flow (RFC 8628).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceCodeFlow {
+    /// URL of the device authorization endpoint.
+    pub device_authorization_url: String,
+
+    /// URL of the token endpoint.
+    pub token_url: String,
+
+    /// URL of the refresh token endpoint.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_url: Option<String>,
+
+    /// Available scopes: name → description.
+    pub scopes: HashMap<String, String>,
+}
+
+/// OAuth 2.0 implicit flow (deprecated; retained for compatibility).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImplicitFlow {
+    /// URL of the authorization endpoint.
+    pub authorization_url: String,
+
+    /// URL of the refresh token endpoint.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_url: Option<String>,
+
+    /// Available scopes: name → description.
+    pub scopes: HashMap<String, String>,
+}
+
+// ── OpenIdConnectSecurityScheme ───────────────────────────────────────────────
+
+/// OpenID Connect security scheme.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenIdConnectSecurityScheme {
+    /// URL of the OpenID Connect discovery document.
+    pub open_id_connect_url: String,
+
+    /// Optional human-readable description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+// ── MutualTlsSecurityScheme ───────────────────────────────────────────────────
+
+/// Mutual TLS security scheme.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MutualTlsSecurityScheme {
+    /// Optional human-readable description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn api_key_scheme_roundtrip() {
+        let scheme = SecurityScheme::ApiKey(ApiKeySecurityScheme {
+            location: ApiKeyLocation::Header,
+            name: "X-API-Key".into(),
+            description: None,
+        });
+        let json = serde_json::to_string(&scheme).expect("serialize");
+        assert!(
+            json.contains("\"type\":\"apiKey\""),
+            "tag must be present: {json}"
+        );
+        assert!(
+            json.contains("\"in\":\"header\""),
+            "location must use 'in': {json}"
+        );
+
+        let back: SecurityScheme = serde_json::from_str(&json).expect("deserialize");
+        assert!(matches!(back, SecurityScheme::ApiKey(_)));
+    }
+
+    #[test]
+    fn http_bearer_scheme_roundtrip() {
+        let scheme = SecurityScheme::Http(HttpAuthSecurityScheme {
+            scheme: "bearer".into(),
+            bearer_format: Some("JWT".into()),
+            description: None,
+        });
+        let json = serde_json::to_string(&scheme).expect("serialize");
+        assert!(json.contains("\"type\":\"http\""));
+        let back: SecurityScheme = serde_json::from_str(&json).expect("deserialize");
+        if let SecurityScheme::Http(h) = back {
+            assert_eq!(h.bearer_format.as_deref(), Some("JWT"));
+        } else {
+            panic!("wrong variant");
+        }
+    }
+
+    #[test]
+    fn oauth2_scheme_roundtrip() {
+        let scheme = SecurityScheme::OAuth2(Box::new(OAuth2SecurityScheme {
+            flows: OAuthFlows {
+                authorization_code: None,
+                client_credentials: Some(ClientCredentialsFlow {
+                    token_url: "https://auth.example.com/token".into(),
+                    refresh_url: None,
+                    scopes: HashMap::from([("read".into(), "Read access".into())]),
+                }),
+                device_code: None,
+                implicit: None,
+            },
+            oauth2_metadata_url: None,
+            description: None,
+        }));
+        let json = serde_json::to_string(&scheme).expect("serialize");
+        assert!(json.contains("\"type\":\"oauth2\""));
+        let back: SecurityScheme = serde_json::from_str(&json).expect("deserialize");
+        assert!(matches!(back, SecurityScheme::OAuth2(_)));
+    }
+
+    #[test]
+    fn mutual_tls_scheme_roundtrip() {
+        let scheme = SecurityScheme::MutualTls(MutualTlsSecurityScheme { description: None });
+        let json = serde_json::to_string(&scheme).expect("serialize");
+        assert!(json.contains("\"type\":\"mutualTLS\""));
+        let back: SecurityScheme = serde_json::from_str(&json).expect("deserialize");
+        assert!(matches!(back, SecurityScheme::MutualTls(_)));
+    }
+
+    #[test]
+    fn api_key_location_serialization() {
+        assert_eq!(
+            serde_json::to_string(&ApiKeyLocation::Header).expect("ser"),
+            "\"header\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ApiKeyLocation::Query).expect("ser"),
+            "\"query\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ApiKeyLocation::Cookie).expect("ser"),
+            "\"cookie\""
+        );
+    }
+}

--- a/crates/a2a-types/src/task.rs
+++ b/crates/a2a-types/src/task.rs
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Tom F.
+
+//! Task types for the A2A protocol.
+//!
+//! A [`Task`] is the stateful unit of work managed by an agent. Its lifecycle
+//! is tracked through [`TaskStatus`] and [`TaskState`]. The [`TaskState`] enum
+//! uses kebab-case serialization to match the A2A wire format (e.g.
+//! `"input-required"`).
+//!
+//! # ID newtypes
+//!
+//! [`TaskId`], [`ContextId`], and [`TaskVersion`] are newtypes over `String`
+//! (or `u64`) for compile-time type safety.
+
+use serde::{Deserialize, Serialize};
+
+use crate::artifact::Artifact;
+use crate::message::Message;
+
+// ── TaskId ────────────────────────────────────────────────────────────────────
+
+/// Opaque unique identifier for a [`Task`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TaskId(pub String);
+
+impl TaskId {
+    /// Creates a new [`TaskId`] from any string-like value.
+    #[must_use]
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+}
+
+impl std::fmt::Display for TaskId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for TaskId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for TaskId {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
+impl AsRef<str> for TaskId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+// ── ContextId ─────────────────────────────────────────────────────────────────
+
+/// Opaque unique identifier for a conversation context.
+///
+/// A context groups related tasks under a single logical conversation thread.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ContextId(pub String);
+
+impl ContextId {
+    /// Creates a new [`ContextId`] from any string-like value.
+    #[must_use]
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+}
+
+impl std::fmt::Display for ContextId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for ContextId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for ContextId {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
+impl AsRef<str> for ContextId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+// ── TaskVersion ───────────────────────────────────────────────────────────────
+
+/// Monotonically increasing version counter for optimistic concurrency control.
+///
+/// Incremented every time a [`Task`] is mutated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct TaskVersion(pub u64);
+
+impl TaskVersion {
+    /// Creates a [`TaskVersion`] from a `u64`.
+    #[must_use]
+    pub const fn new(v: u64) -> Self {
+        Self(v)
+    }
+
+    /// Returns the inner `u64` value.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for TaskVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<u64> for TaskVersion {
+    fn from(v: u64) -> Self {
+        Self(v)
+    }
+}
+
+// ── TaskState ─────────────────────────────────────────────────────────────────
+
+/// The lifecycle state of a [`Task`].
+///
+/// Uses kebab-case serialization to match the A2A wire format
+/// (e.g. `TaskState::InputRequired` ↔ `"input-required"`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TaskState {
+    /// Task received, not yet started.
+    Submitted,
+    /// Task is actively being processed.
+    Working,
+    /// Agent requires additional input from the client to proceed.
+    InputRequired,
+    /// Agent requires the client to complete an authentication step.
+    AuthRequired,
+    /// Task finished successfully.
+    Completed,
+    /// Task finished with an error.
+    Failed,
+    /// Task was canceled by the client.
+    Canceled,
+    /// Task was rejected by the agent before execution.
+    Rejected,
+    /// Task state is unknown (e.g. after a server restart without persistence).
+    Unknown,
+}
+
+impl TaskState {
+    /// Returns `true` if this state is a terminal (final) state.
+    ///
+    /// Terminal states: `Completed`, `Failed`, `Canceled`, `Rejected`.
+    #[must_use]
+    pub const fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Completed | Self::Failed | Self::Canceled | Self::Rejected
+        )
+    }
+}
+
+impl std::fmt::Display for TaskState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Use serde to produce the canonical kebab-case wire representation.
+        let s = serde_json::to_string(self).unwrap_or_else(|_| "unknown".into());
+        // serde_json wraps strings in quotes; strip them.
+        f.write_str(s.trim_matches('"'))
+    }
+}
+
+// ── TaskStatus ────────────────────────────────────────────────────────────────
+
+/// The current status of a [`Task`], combining state with an optional message
+/// and timestamp.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskStatus {
+    /// Current lifecycle state.
+    pub state: TaskState,
+
+    /// Optional agent message accompanying this status (e.g. error details).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<Message>,
+
+    /// ISO 8601 timestamp of when this status was set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+}
+
+impl TaskStatus {
+    /// Creates a [`TaskStatus`] with just a state.
+    #[must_use]
+    pub const fn new(state: TaskState) -> Self {
+        Self {
+            state,
+            message: None,
+            timestamp: None,
+        }
+    }
+}
+
+// ── Task ──────────────────────────────────────────────────────────────────────
+
+/// A unit of work managed by an A2A agent.
+///
+/// The wire `kind` field (`"task"`) is injected by enclosing discriminated
+/// unions such as [`crate::events::StreamResponse`] and
+/// [`crate::responses::SendMessageResponse`]. Standalone `Task` values received
+/// over the wire may include `kind`; serde silently tolerates unknown fields, so
+/// no action is needed on the receiving side.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Task {
+    /// Unique task identifier.
+    pub id: TaskId,
+
+    /// Conversation context this task belongs to.
+    pub context_id: ContextId,
+
+    /// Current status of the task.
+    pub status: TaskStatus,
+
+    /// Historical messages exchanged during this task.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub history: Option<Vec<Message>>,
+
+    /// Artifacts produced by this task.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifacts: Option<Vec<Artifact>>,
+
+    /// Arbitrary metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_task() -> Task {
+        Task {
+            id: TaskId::new("task-1"),
+            context_id: ContextId::new("ctx-1"),
+            status: TaskStatus::new(TaskState::Working),
+            history: None,
+            artifacts: None,
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn task_state_kebab_case() {
+        assert_eq!(
+            serde_json::to_string(&TaskState::InputRequired).expect("ser"),
+            "\"input-required\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TaskState::AuthRequired).expect("ser"),
+            "\"auth-required\""
+        );
+    }
+
+    #[test]
+    fn task_state_is_terminal() {
+        assert!(TaskState::Completed.is_terminal());
+        assert!(TaskState::Failed.is_terminal());
+        assert!(TaskState::Canceled.is_terminal());
+        assert!(TaskState::Rejected.is_terminal());
+        assert!(!TaskState::Working.is_terminal());
+        assert!(!TaskState::Submitted.is_terminal());
+    }
+
+    #[test]
+    fn task_roundtrip() {
+        let task = make_task();
+        let json = serde_json::to_string(&task).expect("serialize");
+        assert!(json.contains("\"id\":\"task-1\""));
+
+        let back: Task = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.id, TaskId::new("task-1"));
+        assert_eq!(back.context_id, ContextId::new("ctx-1"));
+        assert_eq!(back.status.state, TaskState::Working);
+    }
+
+    #[test]
+    fn optional_fields_omitted() {
+        let task = make_task();
+        let json = serde_json::to_string(&task).expect("serialize");
+        assert!(!json.contains("\"history\""), "history should be omitted");
+        assert!(
+            !json.contains("\"artifacts\""),
+            "artifacts should be omitted"
+        );
+        assert!(!json.contains("\"metadata\""), "metadata should be omitted");
+    }
+
+    #[test]
+    fn task_version_ordering() {
+        assert!(TaskVersion::new(2) > TaskVersion::new(1));
+        assert_eq!(TaskVersion::new(5).get(), 5);
+    }
+}


### PR DESCRIPTION
This PR introduces the complete set of Rust type definitions for the A2A (Agent-to-Agent) 0.3.0 protocol specification. The `a2a-types` crate now provides all wire types needed for client and server implementations with zero I/O dependencies.

## Summary

Added 11 new modules containing ~2,500 lines of well-documented, serde-compatible type definitions that comprehensively cover the A2A 0.3.0 specification. All types use appropriate serde attributes for correct JSON serialization/deserialization matching the wire format.

## Key Changes

- **`message.rs`** — Message types with discriminated `Part` union (text/file/data), file content handling (inline bytes or URI), and message metadata
- **`task.rs`** — Task lifecycle management with `TaskState` (kebab-case serialization), `TaskStatus`, and ID newtypes (`TaskId`, `ContextId`, `TaskVersion`) for compile-time type safety
- **`artifact.rs`** — Artifact output types with unique IDs and multi-part content support
- **`agent_card.rs`** — Agent discovery document (`AgentCard`) with capabilities, skills, provider info, and transport protocol support (JSON-RPC, gRPC, REST)
- **`security.rs`** — Complete security scheme types following OpenAPI 3.x model: API key, HTTP auth, OAuth 2.0 (with all flow types), OpenID Connect, and mutual TLS
- **`jsonrpc.rs`** — JSON-RPC 2.0 envelope types (`JsonRpcRequest`, `JsonRpcResponse`, `JsonRpcError`) with strict version validation
- **`error.rs`** — Comprehensive error types with all JSON-RPC 2.0 standard codes (-32700 to -32603) and A2A-specific codes (-32001 to -32011)
- **`events.rs`** — Server-sent event types for streaming: `TaskStatusUpdateEvent`, `TaskArtifactUpdateEvent`, and discriminated `StreamResponse` union
- **`params.rs`** — Method parameter types for all RPC calls (message/send, tasks/get, tasks/list, push notification config operations)
- **`responses.rs`** — RPC response types including `SendMessageResponse` (task or message discriminated union) and `TaskListResponse` with pagination
- **`extensions.rs`** — Extension capability types and agent card signatures
- **`lib.rs`** — Updated with comprehensive module documentation and overview table

## Notable Implementation Details

- **Discriminated unions** use appropriate serde strategies: `#[serde(tag = "kind")]` for `Part` and `StreamResponse`, `#[serde(untagged)]` for `JsonRpcResponse` and `FileContent`
- **Kebab-case serialization** for `TaskState` to match wire format (e.g., `InputRequired` ↔ `"input-required"`)
- **ID newtypes** (`TaskId`, `MessageId`, `ContextId`, `ArtifactId`) provide compile-time type safety with `From`/`AsRef` trait implementations
- **OAuth 2.0 flows** fully modeled: authorization code, client credentials, device code, and implicit flows
- **Error codes** use `#[serde(into = "i32", try_from = "i32")]` for seamless numeric conversion
- **Optional fields** consistently use `#[serde(skip_serializing_if = "Option::is_none")]` to avoid null pollution
- **Raw identifier syntax** (`r#final`) used where Rust keywords conflict with wire field names
- **Comprehensive documentation** with examples, wire format notes, and cross-references between related types

https://claude.ai/code/session_01W83FVWmmeS9AX9oGzkqwVp