### PR TITLE
Add mutation-killing tests for rate limiting, retry logic, and SSE parsing

### DIFF
--- a/crates/a2a-client/src/retry.rs
+++ b/crates/a2a-client/src/retry.rs
@@ -421,7 +421,17 @@ mod tests {
     }
 
     /// A transport that always fails with a non-retryable error.
-    struct NonRetryableErrorTransport;
+    struct NonRetryableErrorTransport {
+        call_count: Arc<AtomicUsize>,
+    }
+
+    impl NonRetryableErrorTransport {
+        fn new() -> Self {
+            Self {
+                call_count: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
 
     impl crate::transport::Transport for NonRetryableErrorTransport {
         fn send_request<'a>(
@@ -430,6 +440,7 @@ mod tests {
             _params: serde_json::Value,
             _extra_headers: &'a HashMap<String, String>,
         ) -> Pin<Box<dyn Future<Output = ClientResult<serde_json::Value>> + Send + 'a>> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
             Box::pin(async move { Err(ClientError::InvalidEndpoint("bad url".into())) })
         }
 
@@ -439,6 +450,7 @@ mod tests {
             _params: serde_json::Value,
             _extra_headers: &'a HashMap<String, String>,
         ) -> Pin<Box<dyn Future<Output = ClientResult<EventStream>> + Send + 'a>> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
             Box::pin(async move { Err(ClientError::InvalidEndpoint("bad url".into())) })
         }
     }
@@ -492,8 +504,10 @@ mod tests {
 
     #[tokio::test]
     async fn retry_transport_no_retry_on_non_retryable() {
+        let inner = NonRetryableErrorTransport::new();
+        let call_count = Arc::clone(&inner.call_count);
         let transport = RetryTransport::new(
-            Box::new(NonRetryableErrorTransport),
+            Box::new(inner),
             RetryPolicy::default()
                 .with_initial_backoff(Duration::from_millis(1))
                 .with_max_retries(3),
@@ -508,6 +522,11 @@ mod tests {
             result.unwrap_err(),
             ClientError::InvalidEndpoint(_)
         ));
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "non-retryable error should not be retried"
+        );
     }
 
     #[tokio::test]
@@ -537,8 +556,10 @@ mod tests {
 
     #[tokio::test]
     async fn retry_transport_streaming_no_retry_on_non_retryable() {
+        let inner = NonRetryableErrorTransport::new();
+        let call_count = Arc::clone(&inner.call_count);
         let transport = RetryTransport::new(
-            Box::new(NonRetryableErrorTransport),
+            Box::new(inner),
             RetryPolicy::default()
                 .with_initial_backoff(Duration::from_millis(1))
                 .with_max_retries(3),
@@ -552,6 +573,11 @@ mod tests {
             result.unwrap_err(),
             ClientError::InvalidEndpoint(_)
         ));
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "non-retryable streaming error should not be retried"
+        );
     }
 
     #[tokio::test]

--- a/crates/a2a-client/src/streaming/sse_parser/parser.rs
+++ b/crates/a2a-client/src/streaming/sse_parser/parser.rs
@@ -426,6 +426,21 @@ mod tests {
     }
 
     #[test]
+    fn default_max_event_size_accepts_over_one_mib() {
+        // Kills mutation: first `*` → `+` in `16 * 1024 * 1024`
+        // which gives 16 + 1024 * 1024 = 1_048_592 (~1 MiB).
+        // A 1.1 MiB event should pass the real 16 MiB limit but fail the mutated ~1 MiB limit.
+        let data = format!("data: {}\n\n", "x".repeat(1_100_000));
+        let mut parser = SseParser::new();
+        parser.feed(data.as_bytes());
+        let frame = parser.next_frame().expect("should have a frame");
+        assert!(
+            frame.is_ok(),
+            "1.1 MiB event should be within default 16 MiB limit"
+        );
+    }
+
+    #[test]
     fn bom_at_stream_start_is_stripped() {
         // Tests BOM stripping in feed() — covers mutations on lines 157 and 163.
         let mut p = SseParser::new();

--- a/crates/a2a-server/src/rate_limit.rs
+++ b/crates/a2a-server/src/rate_limit.rs
@@ -700,6 +700,46 @@ mod tests {
         );
     }
 
+    /// Kills mutations on line 164: `&& → ||` and `> → >=`.
+    ///
+    /// With `&&`: `0 > 0 && 0.is_multiple_of(256)` = `false && true` = `false` → no cleanup.
+    /// With `||`: `0 > 0 || 0.is_multiple_of(256)` = `false || true` = `true` → cleanup (wrong!).
+    /// With `>=`: `0 >= 0 && 0.is_multiple_of(256)` = `true && true` = `true` → cleanup (wrong!).
+    #[tokio::test]
+    async fn cleanup_does_not_run_on_first_call() {
+        let limiter = RateLimitInterceptor::new(RateLimitConfig {
+            requests_per_window: 10000,
+            window_secs: 60,
+        });
+
+        // Insert a stale bucket before any calls.
+        {
+            let mut buckets = limiter.buckets.write().await;
+            buckets.insert(
+                "stale-first-call".to_string(),
+                CallerBucket {
+                    window_start: AtomicU64::new(0),
+                    count: AtomicU64::new(1),
+                },
+            );
+        }
+
+        // Make one call. check_count starts at 0; fetch_add returns 0.
+        // With correct code: count(0) > 0 is false → no cleanup.
+        let ctx = make_ctx(Some("first-caller"));
+        assert!(limiter.before(&ctx).await.is_ok());
+
+        // The stale bucket should still exist (no cleanup on first call).
+        assert!(
+            limiter
+                .buckets
+                .read()
+                .await
+                .contains_key("stale-first-call"),
+            "stale bucket should not be cleaned up on the very first call"
+        );
+    }
+
     /// Covers the `caller_key` function with an empty x-forwarded-for (no commas).
     #[tokio::test]
     async fn x_forwarded_for_single_ip() {


### PR DESCRIPTION
## Summary
This PR adds comprehensive test coverage to catch common mutations in critical logic paths across three modules: rate limiting, retry transport, and SSE parsing. These tests are specifically designed to detect subtle bugs that could be introduced by operator changes or logic inversions.

## Key Changes

- **Rate Limiting (`rate_limit.rs`)**: Added `cleanup_does_not_run_on_first_call()` test that verifies cleanup logic doesn't execute on the first interceptor call. This test catches mutations where `&&` is changed to `||` or `>` is changed to `>=` in the cleanup condition (line 164).

- **Retry Transport (`retry.rs`)**: Enhanced `NonRetryableErrorTransport` to track call counts via `Arc<AtomicUsize>`, allowing verification that non-retryable errors are not retried. Updated both `retry_transport_no_retry_on_non_retryable()` and `retry_transport_streaming_no_retry_on_non_retryable()` tests to assert exactly one call is made, catching mutations that would incorrectly enable retries.

- **SSE Parser (`sse_parser/parser.rs`)**: Added `default_max_event_size_accepts_over_one_mib()` test that verifies the default 16 MiB event size limit is correctly enforced. This test catches mutations where multiplication operators in `16 * 1024 * 1024` are changed to addition, which would reduce the limit to ~1 MiB.

## Implementation Details

Each test includes detailed comments explaining:
- What mutation it's designed to kill
- The specific operator or logic change being tested
- Why the mutation would cause incorrect behavior
- Expected vs. mutated behavior outcomes

These tests follow mutation testing best practices by targeting boundary conditions and operator-specific mutations that could easily slip through without explicit verification.

https://claude.ai/code/session_0145eyhDHn4HFZDoXncMj8T8