### PR TITLE
Fix Chart.js resize for charts in hidden tab panels

### DIFF
--- a/benches/dashboard/template.html
+++ b/benches/dashboard/template.html
@@ -179,6 +179,12 @@ function activate(id){
   document.querySelectorAll(".tab-panel").forEach(function(p){p.classList.remove("active");p.setAttribute("hidden","")});
   var tab=$("#tab-"+id);tab.setAttribute("aria-selected","true");tab.tabIndex=0;
   var panel=$("#panel-"+id);panel.classList.add("active");panel.removeAttribute("hidden");
+  /* Trigger Chart.js resize after layout reflow for charts created in hidden panels */
+  requestAnimationFrame(function(){
+    panel.querySelectorAll("canvas").forEach(function(cv){
+      var ci=Chart.getChart(cv);if(ci)ci.resize();
+    });
+  });
 }
 
 /* --- Overview --- */

--- a/book/src/reference/benchmark-dashboard.html
+++ b/book/src/reference/benchmark-dashboard.html
@@ -2705,6 +2705,12 @@ function activate(id){
   document.querySelectorAll(".tab-panel").forEach(function(p){p.classList.remove("active");p.setAttribute("hidden","")});
   var tab=$("#tab-"+id);tab.setAttribute("aria-selected","true");tab.tabIndex=0;
   var panel=$("#panel-"+id);panel.classList.add("active");panel.removeAttribute("hidden");
+  /* Trigger Chart.js resize after layout reflow for charts created in hidden panels */
+  requestAnimationFrame(function(){
+    panel.querySelectorAll("canvas").forEach(function(cv){
+      var ci=Chart.getChart(cv);if(ci)ci.resize();
+    });
+  });
 }
 
 /* --- Overview --- */


### PR DESCRIPTION
## Summary
This PR fixes an issue where Chart.js charts created in hidden tab panels were not properly resizing when their containing tab became visible. The fix ensures charts are resized after the DOM layout reflow occurs when switching tabs.

## Changes
- Added `requestAnimationFrame` callback to the tab switching function that triggers Chart.js resize for all canvas elements in the newly visible panel
- Applied the fix to both the benchmark dashboard template and the reference documentation
- The resize is deferred to the next animation frame to allow the browser to complete the layout reflow before Chart.js recalculates dimensions

## Implementation Details
When a tab panel transitions from hidden to visible, Chart.js charts within that panel need to be explicitly resized since they were rendered while their container had `display: none` or similar hidden state. The fix:
1. Waits for the next animation frame using `requestAnimationFrame` to ensure the layout has reflowed
2. Queries all canvas elements in the newly active panel
3. Retrieves the Chart.js instance for each canvas and calls its `resize()` method if it exists

This ensures charts display with correct dimensions immediately after tab activation.

https://claude.ai/code/session_01JMApLxRnxbdgtrCjcQwFTH