### PR TITLE
Protocol audit fixes: push config optionality, JSON-RPC null id, rate limiter hardening, response caps, RFC 8785 edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,61 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Interop, hardening, and edge-case fixes from an independent protocol audit.
+Several public types changed shape (0.x breaking — warrants a minor bump).
+
+### Changed
+
+- **`a2a-protocol-types`: push types accept spec-compliant JSON** —
+  `AuthenticationInfo.credentials` and `TaskPushNotificationConfig.taskId`
+  are now `Option<String>`, matching the canonical protocol schema (both
+  were previously required, rejecting valid cross-SDK payloads at parse
+  time — e.g. a push config nested in `SendMessageConfiguration` before the
+  task exists). A standalone `CreateTaskPushNotificationConfig` without a
+  `taskId` is now rejected by the server with a structured invalid-params
+  error instead of a parse error; all push-config stores guard the missing
+  routing key explicitly.
+- **`a2a-protocol-types`: JSON-RPC request ids are three-state** —
+  `JsonRpcRequest.id` is now the `JsonRpcRequestId` enum
+  (`Absent`/`Null`/`Value`). An explicit `"id": null` request previously
+  collapsed into a notification on round-trip; per JSON-RPC 2.0 it is a
+  *call* and now round-trips faithfully. Server responses are unchanged.
+- **`a2a-protocol-server`: concurrent streams capped at 1024 by default** —
+  `max_concurrent_streams` previously defaulted to unlimited; every stream
+  eagerly allocates channels and spawns tasks, an unauthenticated DoS
+  vector. Deployments needing more must raise the cap explicitly
+  (`usize::MAX` effectively disables it). `executor_timeout` deliberately
+  keeps no default, now documented as a production recommendation.
+- **`a2a-protocol-server`: `RateLimitInterceptor` hardened** — caller
+  identity no longer trusts the client-controlled `X-Forwarded-For` header
+  unless `RateLimitConfig::trusted_proxy_hops` is set (forged headers
+  previously bypassed the limit entirely); the bucket map is bounded by
+  `max_buckets` (default 10,000); `RateLimitInterceptor::new` is now
+  fallible and rejects zero config values (`window_secs == 0` previously
+  panicked with a divide-by-zero at request time).
+- **`a2a-protocol-client`: buffered response bodies capped** — unary
+  responses were collected with no size limit; they are now capped at
+  32 MiB by default (configurable via
+  `ClientBuilder::with_max_response_size`), enforced during the read.
+
+### Fixed
+
+- **`a2a-protocol-types`: ambiguous `Part` content rejected** — a part
+  carrying more than one content member (`text`/`raw`/`url`/`data`) was
+  silently coalesced to the first match; it now fails deserialization.
+- **`a2a-protocol-types`: RFC 8785 canonicalization conformance (signing)**
+  — object keys now sort by UTF-16 code units (§3.2.3) and doubles use
+  ECMAScript `Number::toString` formatting (§3.2.2), fixing cross-SDK
+  signature mismatches for cards containing supplementary-plane keys or
+  non-integer numbers in `AgentExtension.params`.
+- **WebSocket (opt-in)**: the server's 4 MiB message cap is now enforced at
+  the protocol level via `WebSocketConfig` (previously tungstenite's 64 MiB
+  default applied and oversized messages were fully buffered before the
+  check); the client no longer leaks a pending-request map entry per
+  timed-out request.
+
 ## [0.6.0] - 2026-06-10
 
 Released as a **minor** (not patch) bump: no public API signatures changed,

--- a/benches/benches/enterprise_scenarios.rs
+++ b/benches/benches/enterprise_scenarios.rs
@@ -316,8 +316,10 @@ fn bench_rate_limiting(c: &mut Criterion) {
     let rate_config = a2a_protocol_server::RateLimitConfig {
         requests_per_window: 100_000,
         window_secs: 60,
+        ..a2a_protocol_server::RateLimitConfig::default()
     };
-    let rate_limiter = a2a_protocol_server::RateLimitInterceptor::new(rate_config);
+    let rate_limiter =
+        a2a_protocol_server::RateLimitInterceptor::new(rate_config).expect("valid config");
 
     let handler = Arc::new(
         a2a_protocol_server::builder::RequestHandlerBuilder::new(EchoExecutor)

--- a/benches/benches/enterprise_scenarios.rs
+++ b/benches/benches/enterprise_scenarios.rs
@@ -188,7 +188,10 @@ fn bench_push_config_store(c: &mut Criterion) {
             );
             let saved = rt.block_on(store.set(config)).unwrap();
             if i == 50 {
-                config_ids.push((saved.task_id.clone(), saved.id.clone().unwrap_or_default()));
+                config_ids.push((
+                    saved.task_id.clone().unwrap_or_default(),
+                    saved.id.clone().unwrap_or_default(),
+                ));
             }
         }
         let (task_id, config_id) = &config_ids[0];

--- a/book/src/building-agents/interceptors.md
+++ b/book/src/building-agents/interceptors.md
@@ -154,10 +154,14 @@ The built-in `RateLimitInterceptor` provides per-caller fixed-window rate limiti
 use a2a_protocol_sdk::server::{RateLimitInterceptor, RateLimitConfig};
 use std::sync::Arc;
 
-let limiter = Arc::new(RateLimitInterceptor::new(RateLimitConfig {
-    requests_per_window: 100,
-    window_secs: 60,
-}));
+let limiter = Arc::new(
+    RateLimitInterceptor::new(RateLimitConfig {
+        requests_per_window: 100,
+        window_secs: 60,
+        ..RateLimitConfig::default()
+    })
+    .expect("valid rate limit config"),
+);
 
 // Add to handler builder:
 RequestHandlerBuilder::new(my_executor)
@@ -166,7 +170,10 @@ RequestHandlerBuilder::new(my_executor)
 ```
 
 Caller keys are derived from `CallContext::caller_identity()` (set by auth
-interceptors), the `X-Forwarded-For` header, or `"anonymous"`.
+interceptors) or `"anonymous"`. The `X-Forwarded-For` header is only consulted
+when `trusted_proxy_hops` is set to the number of trusted reverse proxies in
+front of the server — the header is client-controlled, so it is ignored by
+default. The bucket map is bounded by `max_buckets` (default 10,000).
 
 > **Note:** `CallContext` fields are read-only (accessed via methods like
 > `ctx.method()`, `ctx.caller_identity()`, `ctx.http_headers()`). This

--- a/book/src/deployment/production.md
+++ b/book/src/deployment/production.md
@@ -111,10 +111,17 @@ Protect public-facing agents from abuse:
 use a2a_protocol_sdk::server::{RateLimitInterceptor, RateLimitConfig};
 
 RequestHandlerBuilder::new(executor)
-    .with_interceptor(RateLimitInterceptor::new(RateLimitConfig {
-        requests_per_window: 100,
-        window_secs: 60,
-    }))
+    .with_interceptor(
+        RateLimitInterceptor::new(RateLimitConfig {
+            requests_per_window: 100,
+            window_secs: 60,
+            // Set to the number of trusted reverse proxies so the client IP
+            // is taken from X-Forwarded-For; 0 (default) ignores the header.
+            trusted_proxy_hops: 1,
+            ..RateLimitConfig::default()
+        })
+        .expect("valid rate limit config"),
+    )
     .build()
 ```
 

--- a/book/src/deployment/production.md
+++ b/book/src/deployment/production.md
@@ -51,7 +51,9 @@ The REST dispatcher automatically rejects:
 
 ### Executor Timeout
 
-Prevent hung tasks from consuming resources forever:
+Prevent hung tasks from consuming resources forever. There is deliberately no
+default (a fixed value would silently fail legitimately long-running agent
+tasks) — set one matched to your workload:
 
 ```rust
 use std::time::Duration;
@@ -63,7 +65,9 @@ RequestHandlerBuilder::new(executor)
 
 ### Concurrent Stream Limits
 
-Bound memory usage from SSE connections:
+Concurrent streaming requests are capped at 1024 by default (each stream
+allocates channels and spawns background tasks). Tune the ceiling to your
+deployment; pass `usize::MAX` to effectively disable it:
 
 ```rust
 RequestHandlerBuilder::new(executor)

--- a/crates/a2a-protocol-client/src/builder/mod.rs
+++ b/crates/a2a-protocol-client/src/builder/mod.rs
@@ -184,6 +184,17 @@ impl ClientBuilder {
         self
     }
 
+    /// Sets the maximum size in bytes of a buffered (non-streaming) response
+    /// body. Responses exceeding the cap fail with a transport error instead
+    /// of being buffered without bound.
+    ///
+    /// Defaults to 32 MiB.
+    #[must_use]
+    pub const fn with_max_response_size(mut self, max_bytes: usize) -> Self {
+        self.config.max_response_size = max_bytes;
+        self
+    }
+
     /// Sets the preferred protocol binding.
     ///
     /// Overrides any binding derived from the agent card.

--- a/crates/a2a-protocol-client/src/builder/transport_factory.rs
+++ b/crates/a2a-protocol-client/src/builder/transport_factory.rs
@@ -57,7 +57,8 @@ impl ClientBuilder {
                         self.config.request_timeout,
                         self.config.stream_connect_timeout,
                         self.config.connection_timeout,
-                    )?;
+                    )?
+                    .with_max_response_size(self.config.max_response_size);
                     Box::new(t)
                 }
                 BINDING_REST => {
@@ -66,7 +67,8 @@ impl ClientBuilder {
                         self.config.request_timeout,
                         self.config.stream_connect_timeout,
                         self.config.connection_timeout,
-                    )?;
+                    )?
+                    .with_max_response_size(self.config.max_response_size);
                     Box::new(t)
                 }
                 #[cfg(feature = "grpc")]

--- a/crates/a2a-protocol-client/src/config.rs
+++ b/crates/a2a-protocol-client/src/config.rs
@@ -103,6 +103,14 @@ pub struct ClientConfig {
     /// when the server is unreachable. Defaults to 10 seconds.
     pub connection_timeout: Duration,
 
+    /// Maximum size in bytes of a buffered (non-streaming) response body.
+    ///
+    /// Responses exceeding this cap fail with a transport error instead of
+    /// being buffered without bound. Defaults to 32 MiB — large enough for
+    /// big task histories and inline artifacts while still bounding client
+    /// memory against a hostile or buggy server.
+    pub max_response_size: usize,
+
     /// TLS configuration.
     pub tls: TlsConfig,
 
@@ -127,6 +135,7 @@ impl ClientConfig {
             request_timeout: Duration::from_secs(30),
             stream_connect_timeout: Duration::from_secs(30),
             connection_timeout: Duration::from_secs(10),
+            max_response_size: crate::transport::DEFAULT_MAX_RESPONSE_SIZE,
             tls: TlsConfig::Disabled,
             tenant: None,
         }
@@ -143,6 +152,7 @@ impl Default for ClientConfig {
             request_timeout: Duration::from_secs(30),
             stream_connect_timeout: Duration::from_secs(30),
             connection_timeout: Duration::from_secs(10),
+            max_response_size: crate::transport::DEFAULT_MAX_RESPONSE_SIZE,
             tls: TlsConfig::default(),
             tenant: None,
         }

--- a/crates/a2a-protocol-client/src/transport/jsonrpc.rs
+++ b/crates/a2a-protocol-client/src/transport/jsonrpc.rs
@@ -21,7 +21,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
-use http_body_util::{BodyExt, Full};
+use http_body_util::Full;
 use hyper::body::Bytes;
 use hyper::header;
 #[cfg(not(feature = "tls-rustls"))]
@@ -58,12 +58,13 @@ pub struct JsonRpcTransport {
     inner: Arc<Inner>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct Inner {
     client: HttpClient,
     endpoint: String,
     request_timeout: Duration,
     stream_connect_timeout: Duration,
+    max_response_size: usize,
 }
 
 impl JsonRpcTransport {
@@ -149,8 +150,20 @@ impl JsonRpcTransport {
                 endpoint,
                 request_timeout,
                 stream_connect_timeout,
+                max_response_size: super::DEFAULT_MAX_RESPONSE_SIZE,
             }),
         })
+    }
+
+    /// Sets the maximum size in bytes of a buffered (non-streaming) response
+    /// body. Responses exceeding the cap fail with a non-retryable transport
+    /// error instead of being buffered without bound.
+    ///
+    /// Defaults to 32 MiB.
+    #[must_use]
+    pub fn with_max_response_size(mut self, max_bytes: usize) -> Self {
+        Arc::make_mut(&mut self.inner).max_response_size = max_bytes;
+        self
     }
 
     /// Returns the endpoint URL this transport targets.
@@ -223,14 +236,19 @@ impl JsonRpcTransport {
         let status = resp.status();
         trace_debug!(method, %status, "received response");
 
-        let body_bytes = tokio::time::timeout(self.inner.request_timeout, resp.collect())
-            .await
-            .map_err(|_| {
-                trace_error!(method, "response body read timed out");
-                ClientError::Timeout("response body read timed out".into())
-            })?
-            .map_err(ClientError::Http)?
-            .to_bytes();
+        let body_bytes = match super::collect_response_limited(
+            resp,
+            self.inner.max_response_size,
+            self.inner.request_timeout,
+        )
+        .await
+        {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                trace_error!(method, error = %e, "response body read failed");
+                return Err(e);
+            }
+        };
 
         if !status.is_success() {
             let body_str = String::from_utf8_lossy(&body_bytes);
@@ -317,12 +335,12 @@ impl JsonRpcTransport {
 
         let status = resp.status();
         if !status.is_success() {
-            let body_bytes =
-                tokio::time::timeout(self.inner.stream_connect_timeout, resp.collect())
-                    .await
-                    .map_err(|_| ClientError::Timeout("error body read timed out".into()))?
-                    .map_err(ClientError::Http)?
-                    .to_bytes();
+            let body_bytes = super::collect_response_limited(
+                resp,
+                self.inner.max_response_size,
+                self.inner.stream_connect_timeout,
+            )
+            .await?;
             let body_str = String::from_utf8_lossy(&body_bytes);
             return Err(ClientError::UnexpectedStatus {
                 status: status.as_u16(),
@@ -341,12 +359,12 @@ impl JsonRpcTransport {
             .unwrap_or("")
             .to_ascii_lowercase();
         if !content_type.starts_with("text/event-stream") {
-            let body_bytes =
-                tokio::time::timeout(self.inner.stream_connect_timeout, resp.collect())
-                    .await
-                    .map_err(|_| ClientError::Timeout("error body read timed out".into()))?
-                    .map_err(ClientError::Http)?
-                    .to_bytes();
+            let body_bytes = super::collect_response_limited(
+                resp,
+                self.inner.max_response_size,
+                self.inner.stream_connect_timeout,
+            )
+            .await?;
             return Err(non_sse_stream_response_error(&content_type, &body_bytes));
         }
 
@@ -483,6 +501,8 @@ fn validate_url(url: &str) -> ClientResult<()> {
 
 #[cfg(test)]
 mod tests {
+    use http_body_util::BodyExt;
+
     use super::*;
 
     #[test]
@@ -823,6 +843,106 @@ mod tests {
             .await;
         let value = result.unwrap();
         assert_eq!(value["hello"], "world");
+    }
+
+    /// Regression (D5): a response whose Content-Length exceeds the cap is
+    /// rejected before the body is read — previously `resp.collect()` had no
+    /// size cap, so the client buffered arbitrarily large responses (bounded
+    /// only by the request timeout).
+    #[tokio::test]
+    async fn oversized_response_rejected_by_content_length() {
+        let big = format!(
+            r#"{{"jsonrpc":"2.0","id":"1","result":{{"pad":"{}"}}}}"#,
+            "x".repeat(64 * 1024)
+        );
+        let addr = start_server(200, big).await;
+        let url = format!("http://127.0.0.1:{}", addr.port());
+        let transport = JsonRpcTransport::new(&url)
+            .unwrap()
+            .with_max_response_size(1024);
+        let result = transport
+            .execute_request("GetTask", serde_json::json!({}), &HashMap::new())
+            .await;
+        match result {
+            Err(ClientError::Transport(msg)) => {
+                assert!(msg.contains("too large"), "got: {msg}");
+            }
+            other => panic!("expected Transport 'too large' error, got {other:?}"),
+        }
+    }
+
+    /// Regression (D5): a chunked response (no Content-Length) is aborted
+    /// *during* the read once the accumulated body exceeds the cap.
+    #[tokio::test]
+    async fn oversized_chunked_response_aborted_mid_read() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            loop {
+                let (stream, _) = listener.accept().await.unwrap();
+                let io = hyper_util::rt::TokioIo::new(stream);
+                tokio::spawn(async move {
+                    let service = hyper::service::service_fn(|_req| async {
+                        // 64 × 64 KiB frames = 4 MiB, streamed without a
+                        // Content-Length header.
+                        let chunks: Vec<
+                            Result<hyper::body::Frame<Bytes>, std::convert::Infallible>,
+                        > = (0..64)
+                            .map(|_| {
+                                Ok(hyper::body::Frame::data(Bytes::from(vec![b'x'; 64 * 1024])))
+                            })
+                            .collect();
+                        let body =
+                            http_body_util::StreamBody::new(futures_util::stream::iter(chunks));
+                        Ok::<_, hyper::Error>(
+                            hyper::Response::builder()
+                                .status(200)
+                                .header("content-type", "application/json")
+                                .body(body)
+                                .unwrap(),
+                        )
+                    });
+                    let _ = hyper_util::server::conn::auto::Builder::new(
+                        hyper_util::rt::TokioExecutor::new(),
+                    )
+                    .serve_connection(io, service)
+                    .await;
+                });
+            }
+        });
+
+        let url = format!("http://127.0.0.1:{}", addr.port());
+        let transport = JsonRpcTransport::new(&url)
+            .unwrap()
+            .with_max_response_size(1024 * 1024);
+        let result = transport
+            .execute_request("GetTask", serde_json::json!({}), &HashMap::new())
+            .await;
+        match result {
+            Err(ClientError::Transport(msg)) => {
+                assert!(msg.contains("too large"), "got: {msg}");
+            }
+            other => panic!("expected Transport 'too large' error, got {other:?}"),
+        }
+    }
+
+    /// A large response *under* the cap still succeeds — the default must not
+    /// reject legitimately big task histories.
+    #[tokio::test]
+    async fn large_response_under_cap_succeeds() {
+        let big = format!(
+            r#"{{"jsonrpc":"2.0","id":"__ID__","result":{{"pad":"{}"}}}}"#,
+            "y".repeat(256 * 1024)
+        );
+        let addr = start_server(200, big).await;
+        let url = format!("http://127.0.0.1:{}", addr.port());
+        let transport = JsonRpcTransport::new(&url).unwrap();
+        let value = transport
+            .execute_request("GetTask", serde_json::json!({}), &HashMap::new())
+            .await
+            .expect("large response under the default cap must succeed");
+        assert_eq!(value["pad"].as_str().unwrap().len(), 256 * 1024);
     }
 
     #[tokio::test]

--- a/crates/a2a-protocol-client/src/transport/mod.rs
+++ b/crates/a2a-protocol-client/src/transport/mod.rs
@@ -38,6 +38,66 @@ pub use websocket::WebSocketTransport;
 /// Maximum length for response body snippets included in error messages.
 const MAX_ERROR_BODY_LEN: usize = 512;
 
+/// Default cap on buffered (non-streaming) response bodies, in bytes.
+///
+/// Large enough for legitimately big task histories and inline artifacts
+/// (8× the server's default 4 MiB request-body cap, and above its default
+/// 16 MiB event-size cap) while still bounding client memory against a
+/// hostile or buggy server. Override via
+/// [`crate::ClientBuilder::with_max_response_size`].
+pub(crate) const DEFAULT_MAX_RESPONSE_SIZE: usize = 32 * 1024 * 1024;
+
+/// Collects a response body, enforcing `max_size` **during** the read.
+///
+/// Mirrors the server's `read_body_limited` pattern: an honest
+/// `Content-Length` beyond the cap is rejected before reading any bytes, and
+/// chunked/HTTP-2 bodies (which advertise no length) are aborted by
+/// [`http_body_util::Limited`] as soon as the accumulated size would exceed
+/// `max_size` — previously such bodies were buffered without bound, limited
+/// only by the request timeout.
+///
+/// Over-limit responses map to a non-retryable [`ClientError::Transport`];
+/// genuine transport failures keep their retryable [`ClientError::Http`]
+/// classification.
+pub(crate) async fn collect_response_limited(
+    resp: hyper::Response<hyper::body::Incoming>,
+    max_size: usize,
+    read_timeout: std::time::Duration,
+) -> crate::error::ClientResult<hyper::body::Bytes> {
+    use http_body_util::{BodyExt, LengthLimitError, Limited};
+
+    use crate::error::ClientError;
+
+    let body = resp.into_body();
+    let size_hint = <hyper::body::Incoming as hyper::body::Body>::size_hint(&body);
+    if let Some(upper) = size_hint.upper() {
+        if upper > max_size as u64 {
+            return Err(ClientError::Transport(format!(
+                "response body too large: {upper} bytes exceeds {max_size} byte limit"
+            )));
+        }
+    }
+
+    let limited = Limited::new(body, max_size);
+    match tokio::time::timeout(read_timeout, limited.collect()).await {
+        Err(_) => Err(crate::error::ClientError::Timeout(
+            "response body read timed out".into(),
+        )),
+        Ok(Ok(collected)) => Ok(collected.to_bytes()),
+        Ok(Err(err)) => {
+            if err.downcast_ref::<LengthLimitError>().is_some() {
+                return Err(ClientError::Transport(format!(
+                    "response body too large: exceeds {max_size} byte limit"
+                )));
+            }
+            match err.downcast::<hyper::Error>() {
+                Ok(hyper_err) => Err(ClientError::Http(*hyper_err)),
+                Err(other) => Err(ClientError::Transport(other.to_string())),
+            }
+        }
+    }
+}
+
 /// Truncates a response body for inclusion in error messages.
 ///
 /// Uses a char-boundary-safe truncation to avoid panics on multi-byte UTF-8.

--- a/crates/a2a-protocol-client/src/transport/rest/mod.rs
+++ b/crates/a2a-protocol-client/src/transport/rest/mod.rs
@@ -79,12 +79,13 @@ pub struct RestTransport {
     inner: Arc<Inner>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct Inner {
     client: HttpClient,
     base_url: String,
     request_timeout: Duration,
     stream_connect_timeout: Duration,
+    max_response_size: usize,
 }
 
 impl RestTransport {
@@ -174,8 +175,20 @@ impl RestTransport {
                 base_url: base_url.trim_end_matches('/').to_owned(),
                 request_timeout,
                 stream_connect_timeout,
+                max_response_size: super::DEFAULT_MAX_RESPONSE_SIZE,
             }),
         })
+    }
+
+    /// Sets the maximum size in bytes of a buffered (non-streaming) response
+    /// body. Responses exceeding the cap fail with a non-retryable transport
+    /// error instead of being buffered without bound.
+    ///
+    /// Defaults to 32 MiB.
+    #[must_use]
+    pub fn with_max_response_size(mut self, max_bytes: usize) -> Self {
+        Arc::make_mut(&mut self.inner).max_response_size = max_bytes;
+        self
     }
 
     /// Returns the base URL this transport targets.

--- a/crates/a2a-protocol-client/src/transport/rest/request.rs
+++ b/crates/a2a-protocol-client/src/transport/rest/request.rs
@@ -10,7 +10,7 @@
 
 use std::collections::HashMap;
 
-use http_body_util::{BodyExt, Full};
+use http_body_util::Full;
 use hyper::body::Bytes;
 use hyper::header;
 
@@ -135,14 +135,19 @@ impl RestTransport {
 
         let status = resp.status();
         trace_debug!(method, %status, "received response");
-        let body_bytes = tokio::time::timeout(self.inner.request_timeout, resp.collect())
-            .await
-            .map_err(|_| {
-                trace_error!(method, "response body read timed out");
-                ClientError::Timeout("response body read timed out".into())
-            })?
-            .map_err(ClientError::Http)?
-            .to_bytes();
+        let body_bytes = match crate::transport::collect_response_limited(
+            resp,
+            self.inner.max_response_size,
+            self.inner.request_timeout,
+        )
+        .await
+        {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                trace_error!(method, error = %e, "response body read failed");
+                return Err(e);
+            }
+        };
 
         if !status.is_success() {
             let body_str = String::from_utf8_lossy(&body_bytes);
@@ -451,6 +456,27 @@ mod tests {
                 );
             }
             other => panic!("expected Protocol error, got {other:?}"),
+        }
+    }
+
+    /// Regression (D5): REST unary responses are capped like JSON-RPC ones —
+    /// previously `resp.collect()` buffered without bound.
+    #[tokio::test]
+    async fn execute_request_oversized_response_rejected() {
+        let big = format!(r#"{{"pad":"{}"}}"#, "x".repeat(64 * 1024));
+        let addr = start_rest_server(200, "application/json", big).await;
+        let url = format!("http://127.0.0.1:{}", addr.port());
+        let transport = RestTransport::new(&url)
+            .unwrap()
+            .with_max_response_size(1024);
+        let result = transport
+            .execute_request("GetTask", serde_json::json!({"id": "t1"}), &HashMap::new())
+            .await;
+        match result {
+            Err(ClientError::Transport(msg)) => {
+                assert!(msg.contains("too large"), "got: {msg}");
+            }
+            other => panic!("expected Transport 'too large' error, got {other:?}"),
         }
     }
 

--- a/crates/a2a-protocol-client/src/transport/websocket.rs
+++ b/crates/a2a-protocol-client/src/transport/websocket.rs
@@ -266,7 +266,7 @@ impl WebSocketTransport {
         let rpc_req = build_rpc_request(method, params);
         let request_id = rpc_req
             .id
-            .as_ref()
+            .as_value()
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_owned();
@@ -331,7 +331,7 @@ impl WebSocketTransport {
         let rpc_req = build_rpc_request(method, params);
         let request_id = rpc_req
             .id
-            .as_ref()
+            .as_value()
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_owned();
@@ -584,7 +584,7 @@ mod tests {
         let params = req.params.expect("params should be present");
         assert_eq!(params["key"], "val");
         // ID should be a UUID string
-        let id = req.id.expect("id should be present");
+        let id = req.id.as_value().expect("id should be present");
         assert!(id.is_string(), "id should be a string UUID");
         assert!(!id.as_str().unwrap().is_empty(), "id should not be empty");
     }

--- a/crates/a2a-protocol-client/src/transport/websocket.rs
+++ b/crates/a2a-protocol-client/src/transport/websocket.rs
@@ -86,6 +86,10 @@ pub struct WebSocketTransport {
 struct Inner {
     /// Channel to send write commands to the background writer/router task.
     write_tx: mpsc::Sender<WriteCommand>,
+    /// Pending requests keyed by JSON-RPC request ID (shared with the
+    /// reader/writer tasks). Held here so request paths can remove their
+    /// entry on timeout instead of leaking it.
+    pending: Arc<Mutex<HashMap<String, PendingRequest>>>,
     endpoint: String,
     request_timeout: Duration,
     /// Handle to the background reader task for cleanup.
@@ -235,6 +239,7 @@ impl WebSocketTransport {
         Ok(Self {
             inner: Arc::new(Inner {
                 write_tx,
+                pending,
                 endpoint: endpoint_stored,
                 request_timeout,
                 _reader_handle: reader_handle,
@@ -273,16 +278,22 @@ impl WebSocketTransport {
             .write_tx
             .send(WriteCommand {
                 text: body,
-                request_id,
+                request_id: request_id.clone(),
                 pending: PendingRequest::Unary(tx),
             })
             .await
             .map_err(|_| ClientError::Transport("WebSocket writer task closed".into()))?;
 
-        let response_text = tokio::time::timeout(self.inner.request_timeout, rx)
-            .await
-            .map_err(|_| ClientError::Timeout("WebSocket response timed out".into()))?
-            .map_err(|_| ClientError::Transport("WebSocket reader task closed".into()))??;
+        let response_text = match tokio::time::timeout(self.inner.request_timeout, rx).await {
+            Ok(received) => received
+                .map_err(|_| ClientError::Transport("WebSocket reader task closed".into()))??,
+            Err(_elapsed) => {
+                // Remove the pending entry: nothing else will, so every
+                // timed-out request would otherwise leak one map entry.
+                self.inner.pending.lock().await.remove(&request_id);
+                return Err(ClientError::Timeout("WebSocket response timed out".into()));
+            }
+        };
 
         let envelope: JsonRpcResponse<serde_json::Value> =
             serde_json::from_str(&response_text).map_err(ClientError::Serialization)?;
@@ -652,5 +663,48 @@ mod tests {
     fn extract_jsonrpc_id_missing_returns_none() {
         let id = extract_jsonrpc_id(r#"{"jsonrpc":"2.0","result":{}}"#);
         assert!(id.is_none());
+    }
+
+    /// Regression (D6): a request that times out must remove its entry from
+    /// the shared pending map — previously every client-side timeout leaked
+    /// one entry (the server never answers, so `route_frame` never cleans
+    /// it up either).
+    #[tokio::test]
+    async fn timed_out_request_is_removed_from_pending_map() {
+        // A WebSocket server that completes the handshake, swallows frames,
+        // and never responds.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let Ok(mut ws) = tokio_tungstenite::accept_async(stream).await else {
+                        return;
+                    };
+                    while let Some(Ok(_)) = ws.next().await {}
+                });
+            }
+        });
+
+        let transport = WebSocketTransport::connect_with_timeout(
+            format!("ws://{addr}"),
+            Duration::from_millis(100),
+        )
+        .await
+        .expect("connect");
+
+        let err = transport
+            .send_request("GetTask", serde_json::json!({"id": "t1"}), &HashMap::new())
+            .await
+            .expect_err("request must time out");
+        assert!(
+            matches!(err, ClientError::Timeout(_)),
+            "expected timeout, got: {err:?}"
+        );
+
+        assert!(
+            transport.inner.pending.lock().await.is_empty(),
+            "pending map must not retain timed-out requests"
+        );
     }
 }

--- a/crates/a2a-protocol-client/tests/client_method_tests.rs
+++ b/crates/a2a-protocol-client/tests/client_method_tests.rs
@@ -358,7 +358,7 @@ async fn set_push_config_returns_stored_config() {
 
     let config = TaskPushNotificationConfig::new("task-1", "https://example.com/hook");
     let result = client.set_push_config(config).await.unwrap();
-    assert_eq!(result.task_id, "task-1");
+    assert_eq!(result.task_id.as_deref(), Some("task-1"));
     assert_eq!(result.id.as_deref(), Some("config-1"));
 }
 
@@ -391,7 +391,7 @@ async fn get_push_config_returns_config() {
     let client = make_client(transport);
 
     let result = client.get_push_config("task-1", "cfg-1").await.unwrap();
-    assert_eq!(result.task_id, "task-1");
+    assert_eq!(result.task_id.as_deref(), Some("task-1"));
     assert_eq!(result.url, "https://example.com/hook");
 }
 

--- a/crates/a2a-protocol-client/tests/tls_integration_tests.rs
+++ b/crates/a2a-protocol-client/tests/tls_integration_tests.rs
@@ -134,7 +134,7 @@ async fn echo_handler(
         Ok(rpc) => {
             let success = JsonRpcSuccessResponse {
                 jsonrpc: JsonRpcVersion,
-                id: rpc.id,
+                id: rpc.id.to_response_id(),
                 result: serde_json::json!({
                     "method": rpc.method,
                     "echo": true,

--- a/crates/a2a-protocol-server/src/builder.rs
+++ b/crates/a2a-protocol-server/src/builder.rs
@@ -25,6 +25,16 @@ use crate::streaming::EventQueueManager;
 use crate::tenant_config::PerTenantConfig;
 use crate::tenant_resolver::TenantResolver;
 
+/// Default ceiling on concurrent streaming event queues.
+///
+/// Every streaming request eagerly allocates channels and spawns background
+/// tasks, so an *unlimited* default let an unauthenticated caller grow server
+/// memory and task count without bound. 1024 concurrent streams is far above
+/// typical single-instance loads while still bounding resource use; raise it
+/// via [`RequestHandlerBuilder::with_max_concurrent_streams`] (up to
+/// `usize::MAX` to effectively disable the ceiling).
+pub const DEFAULT_MAX_CONCURRENT_STREAMS: usize = 1024;
+
 /// Fluent builder for [`RequestHandler`].
 ///
 /// # Required
@@ -42,6 +52,10 @@ use crate::tenant_resolver::TenantResolver;
 /// - `agent_card`: defaults to `None`.
 /// - `tenant_resolver`: defaults to `None` (no tenant resolution).
 /// - `tenant_config`: defaults to `None` (no per-tenant limits).
+/// - `max_concurrent_streams`: defaults to
+///   [`DEFAULT_MAX_CONCURRENT_STREAMS`] (1024).
+/// - `executor_timeout`: defaults to `None` (unbounded — **recommended** to
+///   set explicitly; see [`with_executor_timeout`](Self::with_executor_timeout)).
 pub struct RequestHandlerBuilder {
     executor: Arc<dyn AgentExecutor>,
     task_store: Option<Arc<dyn TaskStore>>,
@@ -147,6 +161,11 @@ impl RequestHandlerBuilder {
     ///
     /// If the executor does not complete within this duration, the task is
     /// marked as failed with a timeout error.
+    ///
+    /// There is deliberately no default: any fixed value would silently mark
+    /// legitimately long-running agent tasks as failed. Production
+    /// deployments should set a timeout matched to their workload so a hung
+    /// executor cannot pin a task (and its stream resources) forever.
     #[must_use]
     pub const fn with_executor_timeout(mut self, timeout: Duration) -> Self {
         self.executor_timeout = Some(timeout);
@@ -185,8 +204,10 @@ impl RequestHandlerBuilder {
 
     /// Sets the maximum number of concurrent streaming event queues.
     ///
-    /// Limits memory usage from concurrent streams. When the limit is reached,
-    /// new streaming requests will fail.
+    /// Limits memory usage from concurrent streams. When the limit is
+    /// reached, new streaming requests will fail. Defaults to
+    /// [`DEFAULT_MAX_CONCURRENT_STREAMS`] (1024); pass `usize::MAX` to
+    /// effectively disable the ceiling.
     #[must_use]
     pub const fn with_max_concurrent_streams(mut self, max: usize) -> Self {
         self.max_concurrent_streams = Some(max);
@@ -312,9 +333,10 @@ impl RequestHandlerBuilder {
                 if let Some(timeout) = self.event_queue_write_timeout {
                     mgr = mgr.with_write_timeout(timeout);
                 }
-                if let Some(max_streams) = self.max_concurrent_streams {
-                    mgr = mgr.with_max_concurrent_queues(max_streams);
-                }
+                mgr = mgr.with_max_concurrent_queues(
+                    self.max_concurrent_streams
+                        .unwrap_or(DEFAULT_MAX_CONCURRENT_STREAMS),
+                );
                 mgr = mgr.with_metrics(Arc::clone(&self.metrics));
                 mgr
             },
@@ -497,6 +519,36 @@ mod tests {
         let handler = RequestHandlerBuilder::new(TestExecutor).build().unwrap();
         assert!(handler.tenant_resolver().is_none());
         assert!(handler.tenant_config().is_none());
+    }
+
+    /// Regression (D4): the default builder must apply a concurrent-stream
+    /// ceiling — previously it was unlimited, letting an unauthenticated
+    /// caller allocate channels and spawn tasks without bound.
+    #[test]
+    fn builder_default_caps_concurrent_streams() {
+        let handler = RequestHandlerBuilder::new(TestExecutor).build().unwrap();
+        let debug = format!("{:?}", handler.event_queue_manager);
+        assert!(
+            debug.contains(&format!(
+                "max_concurrent_queues: Some({DEFAULT_MAX_CONCURRENT_STREAMS})"
+            )),
+            "default builder should cap concurrent streams at \
+             {DEFAULT_MAX_CONCURRENT_STREAMS}, got: {debug}"
+        );
+    }
+
+    /// An explicit override still wins over the default.
+    #[test]
+    fn builder_max_concurrent_streams_override_wins() {
+        let handler = RequestHandlerBuilder::new(TestExecutor)
+            .with_max_concurrent_streams(7)
+            .build()
+            .unwrap();
+        let debug = format!("{:?}", handler.event_queue_manager);
+        assert!(
+            debug.contains("max_concurrent_queues: Some(7)"),
+            "explicit cap should override the default, got: {debug}"
+        );
     }
 
     #[test]

--- a/crates/a2a-protocol-server/src/dispatch/jsonrpc/mod.rs
+++ b/crates/a2a-protocol-server/src/dispatch/jsonrpc/mod.rs
@@ -247,7 +247,7 @@ impl JsonRpcDispatcher {
         rpc_req: &JsonRpcRequest,
         headers: &HashMap<String, String>,
     ) -> hyper::Response<BoxBody<Bytes, Infallible>> {
-        let id = rpc_req.id.clone();
+        let id = rpc_req.id.to_response_id();
         trace_info!(method = %rpc_req.method, "dispatching JSON-RPC request");
 
         // Streaming methods return SSE, not JSON.
@@ -285,7 +285,7 @@ impl JsonRpcDispatcher {
         rpc_req: &JsonRpcRequest,
         headers: &HashMap<String, String>,
     ) -> Vec<u8> {
-        let id = rpc_req.id.clone();
+        let id = rpc_req.id.to_response_id();
 
         match rpc_req.method.as_str() {
             "SendMessage" | "message/send" => {

--- a/crates/a2a-protocol-server/src/dispatch/jsonrpc/response.rs
+++ b/crates/a2a-protocol-server/src/dispatch/jsonrpc/response.rs
@@ -252,7 +252,7 @@ mod tests {
         use a2a_protocol_types::params::TaskQueryParams;
         let req = JsonRpcRequest {
             jsonrpc: JsonRpcVersion,
-            id: None,
+            id: a2a_protocol_types::jsonrpc::JsonRpcRequestId::Absent,
             method: "GetTask".to_owned(),
             params: None,
         };
@@ -272,7 +272,7 @@ mod tests {
         // Passing a bare integer should produce an InvalidParams error.
         let req = JsonRpcRequest {
             jsonrpc: JsonRpcVersion,
-            id: Some(serde_json::json!(1)),
+            id: a2a_protocol_types::jsonrpc::JsonRpcRequestId::Value(serde_json::json!(1)),
             method: "GetTask".to_owned(),
             params: Some(serde_json::json!(42)),
         };

--- a/crates/a2a-protocol-server/src/dispatch/websocket.rs
+++ b/crates/a2a-protocol-server/src/dispatch/websocket.rs
@@ -228,7 +228,7 @@ async fn process_ws_message(handler: &RequestHandler, text: &str, writer: WsSink
         }
     };
 
-    let id = rpc_req.id.clone();
+    let id = rpc_req.id.to_response_id();
     let headers = HashMap::new();
 
     match rpc_req.method.as_str() {

--- a/crates/a2a-protocol-server/src/dispatch/websocket.rs
+++ b/crates/a2a-protocol-server/src/dispatch/websocket.rs
@@ -45,10 +45,23 @@ use crate::error::ServerError;
 use crate::handler::{RequestHandler, SendMessageResult};
 use crate::streaming::EventQueueReader;
 
+/// Maximum size of an incoming WebSocket message (and frame), in bytes.
+///
+/// Enforced at the protocol level via [`WebSocketConfig`] so oversized
+/// messages abort the read *before* they are buffered — without this,
+/// tungstenite's 64 MiB default applied and the application-level size check
+/// only ran after the full message had been assembled in memory.
+///
+/// [`WebSocketConfig`]: tokio_tungstenite::tungstenite::protocol::WebSocketConfig
+const MAX_WS_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
+
 /// WebSocket-based A2A dispatcher.
 ///
 /// Accepts WebSocket connections and processes JSON-RPC 2.0 messages over the
 /// WebSocket channel. Streaming responses are sent as individual text frames.
+///
+/// Incoming messages are capped at 4 MiB at the WebSocket protocol level;
+/// a connection sending a larger message or frame is terminated.
 pub struct WebSocketDispatcher {
     handler: Arc<RequestHandler>,
 }
@@ -121,7 +134,12 @@ impl WebSocketDispatcher {
 
     /// Handles a single WebSocket connection.
     async fn handle_connection(&self, stream: TcpStream) -> Result<(), WsError> {
-        let ws_stream = tokio_tungstenite::accept_async(stream)
+        // Cap message/frame sizes at the protocol level so oversized input is
+        // rejected during the read, before it is buffered in memory.
+        let ws_config = tokio_tungstenite::tungstenite::protocol::WebSocketConfig::default()
+            .max_message_size(Some(MAX_WS_MESSAGE_SIZE))
+            .max_frame_size(Some(MAX_WS_MESSAGE_SIZE));
+        let ws_stream = tokio_tungstenite::accept_async_with_config(stream, Some(ws_config))
             .await
             .map_err(WsError::Handshake)?;
 
@@ -134,8 +152,9 @@ impl WebSocketDispatcher {
         while let Some(msg) = reader.next().await {
             match msg {
                 Ok(WsMessage::Text(text)) => {
-                    // FIX(M10): Reject oversized WebSocket messages to prevent OOM.
-                    if text.len() > 4 * 1024 * 1024 {
+                    // Defense in depth: the protocol-level cap above already
+                    // rejects oversized messages before buffering.
+                    if text.len() > MAX_WS_MESSAGE_SIZE {
                         let err_resp = JsonRpcErrorResponse::new(
                             None,
                             JsonRpcError::new(-32000, "message too large".to_string()),
@@ -707,7 +726,13 @@ mod tests {
         assert_eq!(v["error"]["code"], -32700, "expected parse error code");
     }
 
-    // 8. Oversized message returns "message too large" error
+    // 8. Oversized message is rejected at the WebSocket protocol level.
+    //
+    // Regression (D6): the 4 MiB cap must be enforced during the read via
+    // WebSocketConfig — previously tungstenite's 64 MiB default applied and
+    // the server fully buffered oversized messages before checking their
+    // size (it then answered with a JSON-RPC "message too large" frame,
+    // proving the message had been assembled in memory).
     #[tokio::test]
     async fn ws_oversized_message_rejected() {
         let addr = spawn_ws_server().await;
@@ -715,16 +740,38 @@ mod tests {
 
         // Create a message > 4MB
         let big = "x".repeat(4 * 1024 * 1024 + 1);
+        // The server drops the connection as soon as the frame header reveals
+        // the oversized payload, so the send itself may already fail
+        // (connection reset mid-write) — that IS the rejection.
+        if ws.send(WsMessage::Text(big.into())).await.is_ok() {
+            // If the send got through, the server must still terminate the
+            // connection without processing: no JSON-RPC frame may arrive.
+            let outcome = tokio::time::timeout(std::time::Duration::from_secs(5), ws.next())
+                .await
+                .expect("server should react to the oversized message");
+            match outcome {
+                None | Some(Err(_) | Ok(WsMessage::Close(_))) => {}
+                Some(Ok(frame)) => panic!(
+                    "server must not answer an oversized message with a frame, got: {frame:?}"
+                ),
+            }
+        }
+    }
+
+    // 8b. A large message *under* the cap is still read and processed
+    // (answered with a JSON-RPC parse error since it is not valid JSON) —
+    // the protocol-level cap must not undershoot the intended 4 MiB.
+    #[tokio::test]
+    async fn ws_large_message_under_cap_still_processed() {
+        let addr = spawn_ws_server().await;
+        let mut ws = ws_connect(addr).await;
+
+        let big = "x".repeat(3 * 1024 * 1024);
         ws.send(WsMessage::Text(big.into())).await.unwrap();
 
         let text = read_text(&mut ws).await;
         let v: serde_json::Value = serde_json::from_str(&text).unwrap();
-        assert!(v.get("error").is_some(), "expected error: {text}");
-        let msg = v["error"]["message"].as_str().unwrap_or("");
-        assert!(
-            msg.contains("too large"),
-            "error should mention 'too large': {msg}"
-        );
+        assert_eq!(v["error"]["code"], -32700, "expected parse error: {text}");
     }
 
     // 9. Ping/Pong

--- a/crates/a2a-protocol-server/src/handler/event_processing/background/push_delivery.rs
+++ b/crates/a2a-protocol-server/src/handler/event_processing/background/push_delivery.rs
@@ -230,7 +230,7 @@ mod tests {
             let config = TaskPushNotificationConfig {
                 tenant: None,
                 id: Some(format!("cfg-{i}")),
-                task_id: "t-deadline".to_owned(),
+                task_id: Some("t-deadline".to_owned()),
                 url: format!("https://example.com/hook{i}"),
                 token: None,
                 authentication: None,
@@ -286,7 +286,7 @@ mod tests {
         let config = TaskPushNotificationConfig {
             tenant: None,
             id: Some("cfg-fail".to_owned()),
-            task_id: "t-fail".to_owned(),
+            task_id: Some("t-fail".to_owned()),
             url: "https://example.com/hook".to_owned(),
             token: None,
             authentication: None,
@@ -331,7 +331,7 @@ mod tests {
         let config = TaskPushNotificationConfig {
             tenant: None,
             id: Some("cfg-timeout".to_owned()),
-            task_id: "t-timeout".to_owned(),
+            task_id: Some("t-timeout".to_owned()),
             url: "https://example.com/hook".to_owned(),
             token: None,
             authentication: None,

--- a/crates/a2a-protocol-server/src/handler/event_processing/sync_collector.rs
+++ b/crates/a2a-protocol-server/src/handler/event_processing/sync_collector.rs
@@ -654,7 +654,7 @@ mod tests {
         let config = TaskPushNotificationConfig {
             tenant: None,
             id: Some("cfg-1".to_owned()),
-            task_id: "t-push".to_owned(),
+            task_id: Some("t-push".to_owned()),
             url: "https://example.com/webhook".to_owned(),
             token: None,
             authentication: None,
@@ -897,7 +897,7 @@ mod tests {
         let config = TaskPushNotificationConfig {
             tenant: None,
             id: Some("cfg-1".to_owned()),
-            task_id: "t-push-fail".to_owned(),
+            task_id: Some("t-push-fail".to_owned()),
             url: "https://example.com/webhook".to_owned(),
             token: None,
             authentication: None,

--- a/crates/a2a-protocol-server/src/handler/push_config.rs
+++ b/crates/a2a-protocol-server/src/handler/push_config.rs
@@ -35,6 +35,15 @@ impl RequestHandler {
             let Some(ref sender) = self.push_sender else {
                 return Err(ServerError::PushNotSupported);
             };
+            // taskId is optional on the wire (a config nested in
+            // SendMessageConfiguration omits it), but a standalone create has
+            // no task context to infer it from — reject explicitly instead of
+            // storing an unroutable config.
+            if config.task_id.as_deref().unwrap_or("").is_empty() {
+                return Err(ServerError::InvalidParams(
+                    "taskId is required for CreateTaskPushNotificationConfig".into(),
+                ));
+            }
             // FIX(#3): Validate webhook URL at config creation time to prevent
             // SSRF attacks. Previously validation only happened at delivery time,
             // leaving a window where malicious URLs could be stored.
@@ -221,7 +230,7 @@ mod tests {
         TaskPushNotificationConfig {
             tenant: None,
             id: Some("cfg-1".to_owned()),
-            task_id: task_id.to_owned(),
+            task_id: Some(task_id.to_owned()),
             url: "https://example.com/webhook".to_owned(),
             token: None,
             authentication: None,
@@ -239,6 +248,55 @@ mod tests {
             matches!(result, Err(crate::error::ServerError::PushNotSupported)),
             "expected PushNotSupported, got: {result:?}"
         );
+    }
+
+    /// Regression (D1): `taskId` is optional on the wire, but a standalone
+    /// `CreateTaskPushNotificationConfig` cannot infer it — the handler must
+    /// reject a missing task ID with `InvalidParams`, not panic or store an
+    /// unroutable config.
+    #[tokio::test]
+    async fn set_push_config_without_task_id_returns_invalid_params() {
+        use crate::push::PushSender;
+        use a2a_protocol_types::events::StreamResponse;
+        use std::future::Future;
+        use std::pin::Pin;
+
+        struct NoopSender;
+        impl PushSender for NoopSender {
+            fn send<'a>(
+                &'a self,
+                _url: &'a str,
+                _event: &'a StreamResponse,
+                _config: &'a TaskPushNotificationConfig,
+            ) -> Pin<Box<dyn Future<Output = a2a_protocol_types::error::A2aResult<()>> + Send + 'a>>
+            {
+                Box::pin(async { Ok(()) })
+            }
+            fn allows_private_urls(&self) -> bool {
+                true
+            }
+        }
+
+        let handler = RequestHandlerBuilder::new(DummyExecutor)
+            .with_push_sender(NoopSender)
+            .build()
+            .unwrap();
+
+        let config = TaskPushNotificationConfig {
+            tenant: None,
+            id: None,
+            task_id: None,
+            url: "https://example.com/webhook".to_owned(),
+            token: None,
+            authentication: None,
+        };
+        let result = handler.on_set_push_config(config, None).await;
+        match result {
+            Err(crate::error::ServerError::InvalidParams(msg)) => {
+                assert!(msg.contains("taskId"), "got: {msg}");
+            }
+            other => panic!("expected InvalidParams for missing taskId, got: {other:?}"),
+        }
     }
 
     // ── on_get_push_config ───────────────────────────────────────────────────

--- a/crates/a2a-protocol-server/src/push/config_store.rs
+++ b/crates/a2a-protocol-server/src/push/config_store.rs
@@ -129,6 +129,13 @@ impl PushConfigStore for InMemoryPushConfigStore {
         mut config: TaskPushNotificationConfig,
     ) -> Pin<Box<dyn Future<Output = A2aResult<TaskPushNotificationConfig>> + Send + 'a>> {
         Box::pin(async move {
+            // A config cannot be stored without its routing key. The handler
+            // rejects this earlier; guard here too for direct store users.
+            let Some(task_id) = config.task_id.clone() else {
+                return Err(a2a_protocol_types::error::A2aError::invalid_params(
+                    "taskId is required to store a push notification config",
+                ));
+            };
             // Assign an ID if not present.
             let id = config
                 .id
@@ -136,7 +143,7 @@ impl PushConfigStore for InMemoryPushConfigStore {
                 .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
             config.id = Some(id.clone());
 
-            let key = (config.task_id.clone(), id);
+            let key = (task_id.clone(), id);
             let mut store = self.configs.write().await;
             let mut counts = self.task_counts.write().await;
 
@@ -157,8 +164,7 @@ impl PushConfigStore for InMemoryPushConfigStore {
                 }
                 // FIX(M11): Use secondary index for O(1) per-task count lookup
                 // instead of scanning all keys.
-                let task_id = &config.task_id;
-                let count = counts.get(task_id).copied().unwrap_or(0);
+                let count = counts.get(&task_id).copied().unwrap_or(0);
                 let max = self.max_configs_per_task;
                 if count >= max {
                     drop(counts);
@@ -171,7 +177,7 @@ impl PushConfigStore for InMemoryPushConfigStore {
 
             store.insert(key, config.clone());
             if is_new {
-                *counts.entry(config.task_id.clone()).or_insert(0) += 1;
+                *counts.entry(task_id).or_insert(0) += 1;
             }
             drop(counts);
             drop(store);
@@ -246,11 +252,31 @@ mod tests {
         TaskPushNotificationConfig {
             tenant: None,
             id: id.map(String::from),
-            task_id: task_id.to_string(),
+            task_id: Some(task_id.to_string()),
             url: url.to_string(),
             token: None,
             authentication: None,
         }
+    }
+
+    /// Regression (D1): storing a config without its `task_id` routing key
+    /// must fail with a proper invalid-params error, not panic.
+    #[tokio::test]
+    async fn set_without_task_id_returns_invalid_params() {
+        let store = InMemoryPushConfigStore::new();
+        let config = TaskPushNotificationConfig {
+            tenant: None,
+            id: None,
+            task_id: None,
+            url: "https://example.com/hook".to_string(),
+            token: None,
+            authentication: None,
+        };
+        let err = store
+            .set(config)
+            .await
+            .expect_err("None task_id must be rejected");
+        assert!(err.to_string().contains("taskId"), "got: {err}");
     }
 
     #[tokio::test]
@@ -300,7 +326,7 @@ mod tests {
             .await
             .expect("get should succeed")
             .expect("config should exist after set");
-        assert_eq!(retrieved.task_id, "task-1");
+        assert_eq!(retrieved.task_id.as_deref(), Some("task-1"));
         assert_eq!(retrieved.url, "https://example.com/hook");
     }
 

--- a/crates/a2a-protocol-server/src/push/postgres_config_store.rs
+++ b/crates/a2a-protocol-server/src/push/postgres_config_store.rs
@@ -83,6 +83,14 @@ impl PushConfigStore for PostgresPushConfigStore {
         mut config: TaskPushNotificationConfig,
     ) -> Pin<Box<dyn Future<Output = A2aResult<TaskPushNotificationConfig>> + Send + 'a>> {
         Box::pin(async move {
+            // A config cannot be stored without its routing key. The handler
+            // rejects this earlier; guard here too so a missing taskId maps to
+            // a proper invalid-params error instead of a NOT NULL violation.
+            let Some(task_id) = config.task_id.clone() else {
+                return Err(A2aError::invalid_params(
+                    "taskId is required to store a push notification config",
+                ));
+            };
             let id = config
                 .id
                 .clone()
@@ -97,7 +105,7 @@ impl PushConfigStore for PostgresPushConfigStore {
                  VALUES ($1, $2, $3)
                  ON CONFLICT(task_id, id) DO UPDATE SET data = EXCLUDED.data",
             )
-            .bind(&config.task_id)
+            .bind(&task_id)
             .bind(&id)
             .bind(&data)
             .execute(&self.pool)

--- a/crates/a2a-protocol-server/src/push/sender.rs
+++ b/crates/a2a-protocol-server/src/push/sender.rs
@@ -469,7 +469,9 @@ impl PushSender for HttpPushSender {
 
             // Header injection protection: validate credentials.
             if let Some(ref auth) = config.authentication {
-                validate_header_value(&auth.credentials, "authentication credentials")?;
+                if let Some(ref credentials) = auth.credentials {
+                    validate_header_value(credentials, "authentication credentials")?;
+                }
                 validate_header_value(&auth.scheme, "authentication scheme")?;
             }
             if let Some(ref token) = config.token {
@@ -496,16 +498,24 @@ impl PushSender for HttpPushSender {
                     builder = builder.uri(url);
                 }
 
-                // Set authentication headers from config.
+                // Set authentication headers from config. A scheme without a
+                // credential value cannot produce an auth header — skip it
+                // rather than sending an empty "Bearer "/"Basic " header.
                 if let Some(ref auth) = config.authentication {
-                    match auth.scheme.as_str() {
-                        "bearer" => {
-                            builder = builder
-                                .header("authorization", format!("Bearer {}", auth.credentials));
+                    match (auth.scheme.as_str(), auth.credentials.as_deref()) {
+                        ("bearer", Some(credentials)) => {
+                            builder =
+                                builder.header("authorization", format!("Bearer {credentials}"));
                         }
-                        "basic" => {
-                            builder = builder
-                                .header("authorization", format!("Basic {}", auth.credentials));
+                        ("basic", Some(credentials)) => {
+                            builder =
+                                builder.header("authorization", format!("Basic {credentials}"));
+                        }
+                        ("bearer" | "basic", None) => {
+                            trace_warn!(
+                                scheme = auth.scheme.as_str(),
+                                "authentication scheme has no credentials; no auth header set"
+                            );
                         }
                         _ => {
                             trace_warn!(

--- a/crates/a2a-protocol-server/src/push/sqlite_config_store.rs
+++ b/crates/a2a-protocol-server/src/push/sqlite_config_store.rs
@@ -98,6 +98,14 @@ impl PushConfigStore for SqlitePushConfigStore {
         mut config: TaskPushNotificationConfig,
     ) -> Pin<Box<dyn Future<Output = A2aResult<TaskPushNotificationConfig>> + Send + 'a>> {
         Box::pin(async move {
+            // A config cannot be stored without its routing key. The handler
+            // rejects this earlier; guard here too so a missing taskId maps to
+            // a proper invalid-params error instead of a NOT NULL violation.
+            let Some(task_id) = config.task_id.clone() else {
+                return Err(A2aError::invalid_params(
+                    "taskId is required to store a push notification config",
+                ));
+            };
             let id = config
                 .id
                 .clone()
@@ -112,7 +120,7 @@ impl PushConfigStore for SqlitePushConfigStore {
                  VALUES (?1, ?2, ?3)
                  ON CONFLICT(task_id, id) DO UPDATE SET data = excluded.data",
             )
-            .bind(&config.task_id)
+            .bind(&task_id)
             .bind(&id)
             .bind(&data)
             .execute(&self.pool)
@@ -202,7 +210,7 @@ mod tests {
         TaskPushNotificationConfig {
             tenant: None,
             id: id.map(String::from),
-            task_id: task_id.to_string(),
+            task_id: Some(task_id.to_string()),
             url: url.to_string(),
             token: None,
             authentication: None,
@@ -240,7 +248,7 @@ mod tests {
 
         let retrieved = store.get("task-1", "cfg-1").await.unwrap();
         let retrieved = retrieved.expect("config should exist after set");
-        assert_eq!(retrieved.task_id, "task-1");
+        assert_eq!(retrieved.task_id.as_deref(), Some("task-1"));
         assert_eq!(retrieved.url, "https://example.com/hook");
         assert_eq!(retrieved.id.as_deref(), Some("cfg-1"));
     }

--- a/crates/a2a-protocol-server/src/push/tenant_config_store.rs
+++ b/crates/a2a-protocol-server/src/push/tenant_config_store.rs
@@ -167,7 +167,7 @@ mod tests {
         TaskPushNotificationConfig {
             tenant: None,
             id: id.map(String::from),
-            task_id: task_id.to_string(),
+            task_id: Some(task_id.to_string()),
             url: url.to_string(),
             token: None,
             authentication: None,

--- a/crates/a2a-protocol-server/src/push/tenant_postgres_config_store.rs
+++ b/crates/a2a-protocol-server/src/push/tenant_postgres_config_store.rs
@@ -88,6 +88,14 @@ impl PushConfigStore for TenantAwarePostgresPushConfigStore {
     ) -> Pin<Box<dyn Future<Output = A2aResult<TaskPushNotificationConfig>> + Send + 'a>> {
         Box::pin(async move {
             let tenant = TenantContext::current();
+            // A config cannot be stored without its routing key. The handler
+            // rejects this earlier; guard here too so a missing taskId maps to
+            // a proper invalid-params error instead of a NOT NULL violation.
+            let Some(task_id) = config.task_id.clone() else {
+                return Err(A2aError::invalid_params(
+                    "taskId is required to store a push notification config",
+                ));
+            };
             let id = config
                 .id
                 .clone()
@@ -103,7 +111,7 @@ impl PushConfigStore for TenantAwarePostgresPushConfigStore {
                  ON CONFLICT(tenant_id, task_id, id) DO UPDATE SET data = EXCLUDED.data",
             )
             .bind(&tenant)
-            .bind(&config.task_id)
+            .bind(&task_id)
             .bind(&id)
             .bind(&data)
             .execute(&self.pool)

--- a/crates/a2a-protocol-server/src/push/tenant_sqlite_config_store.rs
+++ b/crates/a2a-protocol-server/src/push/tenant_sqlite_config_store.rs
@@ -103,6 +103,14 @@ impl PushConfigStore for TenantAwareSqlitePushConfigStore {
     ) -> Pin<Box<dyn Future<Output = A2aResult<TaskPushNotificationConfig>> + Send + 'a>> {
         Box::pin(async move {
             let tenant = TenantContext::current();
+            // A config cannot be stored without its routing key. The handler
+            // rejects this earlier; guard here too so a missing taskId maps to
+            // a proper invalid-params error instead of a NOT NULL violation.
+            let Some(task_id) = config.task_id.clone() else {
+                return Err(A2aError::invalid_params(
+                    "taskId is required to store a push notification config",
+                ));
+            };
             let id = config
                 .id
                 .clone()
@@ -118,7 +126,7 @@ impl PushConfigStore for TenantAwareSqlitePushConfigStore {
                  ON CONFLICT(tenant_id, task_id, id) DO UPDATE SET data = excluded.data",
             )
             .bind(&tenant)
-            .bind(&config.task_id)
+            .bind(&task_id)
             .bind(&id)
             .bind(&data)
             .execute(&self.pool)
@@ -218,7 +226,7 @@ mod tests {
         TaskPushNotificationConfig {
             tenant: None,
             id: id.map(String::from),
-            task_id: task_id.to_string(),
+            task_id: Some(task_id.to_string()),
             url: url.to_string(),
             token: None,
             authentication: None,

--- a/crates/a2a-protocol-server/src/rate_limit.rs
+++ b/crates/a2a-protocol-server/src/rate_limit.rs
@@ -7,7 +7,9 @@
 //!
 //! Provides [`RateLimitInterceptor`], a ready-made interceptor that limits
 //! request throughput per caller. The caller key is derived from
-//! [`CallContext::caller_identity`] or the `x-forwarded-for` / peer IP header.
+//! [`CallContext::caller_identity`]; for unauthenticated callers behind a
+//! trusted reverse proxy, the client IP can be taken from `x-forwarded-for`
+//! (see [`RateLimitConfig::trusted_proxy_hops`]).
 //!
 //! # Example
 //!
@@ -15,10 +17,14 @@
 //! use std::sync::Arc;
 //! use a2a_protocol_server::rate_limit::{RateLimitInterceptor, RateLimitConfig};
 //!
-//! let limiter = Arc::new(RateLimitInterceptor::new(RateLimitConfig {
-//!     requests_per_window: 100,
-//!     window_secs: 60,
-//! }));
+//! let limiter = Arc::new(
+//!     RateLimitInterceptor::new(RateLimitConfig {
+//!         requests_per_window: 100,
+//!         window_secs: 60,
+//!         ..RateLimitConfig::default()
+//!     })
+//!     .expect("valid rate limit config"),
+//! );
 //! ```
 //!
 //! Then add it to the handler builder:
@@ -29,11 +35,30 @@
 //!     .build()?;
 //! ```
 //!
+//! # Caller identity
+//!
+//! The per-caller key is derived in this order:
+//!
+//! 1. [`CallContext::caller_identity`] — set by an authentication interceptor.
+//!    This is the recommended source: it cannot be forged by the client.
+//! 2. The client IP from `x-forwarded-for`, **only** when
+//!    [`RateLimitConfig::trusted_proxy_hops`] is non-zero. The header is
+//!    client-controlled, so by default (`trusted_proxy_hops == 0`) it is
+//!    ignored entirely — otherwise a caller could evade the limit by forging
+//!    a fresh address on every request.
+//! 3. A shared `"anonymous"` key. All remaining callers share one budget,
+//!    which keeps the limit enforceable (fail-closed) at the cost of
+//!    granularity.
+//!
 //! # Design
 //!
 //! Uses a fixed-window counter per caller key. Windows are aligned to wall
 //! clock seconds. When a request exceeds the per-window limit, the `before`
 //! hook returns an error with code `-32029` ("rate limit exceeded").
+//!
+//! The bucket map is bounded by [`RateLimitConfig::max_buckets`]. When the
+//! map is full and stale buckets cannot be evicted, requests from *new*
+//! callers are rejected until capacity frees up (fail-closed).
 //!
 //! For production deployments requiring sliding windows, distributed counters,
 //! or more sophisticated algorithms, implement a custom [`ServerInterceptor`]
@@ -49,23 +74,57 @@ use a2a_protocol_types::error::{A2aError, A2aResult};
 use tokio::sync::RwLock;
 
 use crate::call_context::CallContext;
+use crate::error::{ServerError, ServerResult};
 use crate::interceptor::ServerInterceptor;
 
 /// Configuration for [`RateLimitInterceptor`].
 #[derive(Debug, Clone)]
 pub struct RateLimitConfig {
     /// Maximum number of requests allowed per window per caller key.
+    ///
+    /// Must be non-zero.
     pub requests_per_window: u64,
 
     /// Window duration in seconds.
+    ///
+    /// Must be non-zero.
     pub window_secs: u64,
+
+    /// Number of trusted reverse-proxy hops in front of this server.
+    ///
+    /// `0` (the default) means `x-forwarded-for` is **not trusted** and is
+    /// ignored when deriving the caller key: the header is client-controlled,
+    /// so trusting it without a proxy that overwrites or appends to it lets
+    /// any caller evade the limit by forging a fresh address per request.
+    ///
+    /// Set to `n` when exactly `n` trusted proxies sit between the client and
+    /// this server, each appending the address of its immediate peer to
+    /// `x-forwarded-for`. The client address is then the `n`-th entry from
+    /// the *right* of the header; anything further left is client-supplied
+    /// and remains untrusted. If the header has fewer than `n` entries, the
+    /// request did not traverse the expected proxy chain and the caller falls
+    /// back to the shared `"anonymous"` key.
+    pub trusted_proxy_hops: usize,
+
+    /// Maximum number of caller buckets tracked at once.
+    ///
+    /// Bounds the limiter's memory. When the map is full, stale buckets from
+    /// previous windows are evicted first; if none can be freed, requests
+    /// from callers without an existing bucket are rejected (fail-closed).
+    /// Must be non-zero.
+    pub max_buckets: usize,
 }
+
+/// Default cap on the number of tracked caller buckets.
+pub const DEFAULT_MAX_BUCKETS: usize = 10_000;
 
 impl Default for RateLimitConfig {
     fn default() -> Self {
         Self {
             requests_per_window: 100,
             window_secs: 60,
+            trusted_proxy_hops: 0,
+            max_buckets: DEFAULT_MAX_BUCKETS,
         }
     }
 }
@@ -85,8 +144,9 @@ struct CallerBucket {
 ///
 /// Caller keys are derived in this order:
 /// 1. [`CallContext::caller_identity`] (set by auth interceptors)
-/// 2. `x-forwarded-for` HTTP header (first IP)
-/// 3. `"anonymous"` fallback
+/// 2. Client IP from `x-forwarded-for`, only when
+///    [`RateLimitConfig::trusted_proxy_hops`] is non-zero
+/// 3. `"anonymous"` fallback (shared bucket)
 pub struct RateLimitInterceptor {
     config: RateLimitConfig,
     buckets: RwLock<HashMap<String, CallerBucket>>,
@@ -107,24 +167,61 @@ impl std::fmt::Debug for RateLimitInterceptor {
 
 impl RateLimitInterceptor {
     /// Creates a new rate limiter with the given configuration.
-    #[must_use]
-    pub fn new(config: RateLimitConfig) -> Self {
-        Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ServerError::InvalidParams`] if `requests_per_window`,
+    /// `window_secs`, or `max_buckets` is zero. A zero window would divide by
+    /// zero on every request; a zero limit or bucket cap would reject all
+    /// requests.
+    pub fn new(config: RateLimitConfig) -> ServerResult<Self> {
+        if config.requests_per_window == 0 {
+            return Err(ServerError::InvalidParams(
+                "rate limit requests_per_window must be greater than zero".into(),
+            ));
+        }
+        if config.window_secs == 0 {
+            return Err(ServerError::InvalidParams(
+                "rate limit window_secs must be greater than zero".into(),
+            ));
+        }
+        if config.max_buckets == 0 {
+            return Err(ServerError::InvalidParams(
+                "rate limit max_buckets must be greater than zero".into(),
+            ));
+        }
+        Ok(Self {
             config,
             buckets: RwLock::new(HashMap::new()),
             check_count: AtomicU64::new(0),
-        }
+        })
     }
 
     /// Extracts the caller key from the call context.
-    fn caller_key(ctx: &CallContext) -> String {
+    ///
+    /// See the module docs ("Caller identity") for the derivation order and
+    /// the `x-forwarded-for` trust model.
+    fn caller_key(&self, ctx: &CallContext) -> String {
         if let Some(identity) = ctx.caller_identity() {
             return identity.to_owned();
         }
-        if let Some(xff) = ctx.http_headers().get("x-forwarded-for") {
-            // Use the first IP in the chain (client IP).
-            if let Some(ip) = xff.split(',').next() {
-                return ip.trim().to_string();
+        let hops = self.config.trusted_proxy_hops;
+        if hops > 0 {
+            if let Some(xff) = ctx.http_headers().get("x-forwarded-for") {
+                let entries: Vec<&str> = xff
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|e| !e.is_empty())
+                    .collect();
+                // With `hops` trusted proxies each appending its peer address,
+                // the client address is the `hops`-th entry from the right.
+                // Entries further left are client-supplied and untrusted.
+                if entries.len() >= hops {
+                    return entries[entries.len() - hops].to_string();
+                }
+                // Fewer entries than trusted hops: the request did not come
+                // through the expected proxy chain. Fall through to the
+                // shared anonymous bucket rather than trusting any entry.
             }
         }
         "anonymous".to_string()
@@ -133,6 +230,13 @@ impl RateLimitInterceptor {
     /// Returns the current window number for the given timestamp.
     const fn window_number(&self, now_secs: u64) -> u64 {
         now_secs / self.config.window_secs
+    }
+
+    /// Removes buckets whose window is older than the previous window.
+    fn evict_stale(buckets: &mut HashMap<String, CallerBucket>, current_window: u64) {
+        buckets.retain(|_, bucket| {
+            bucket.window_start.load(Ordering::Relaxed) >= current_window.saturating_sub(1)
+        });
     }
 
     /// Removes buckets whose window is older than the current window.
@@ -147,9 +251,7 @@ impl RateLimitInterceptor {
         let current_window = self.window_number(now_secs);
 
         let mut buckets = self.buckets.write().await;
-        buckets.retain(|_, bucket| {
-            bucket.window_start.load(Ordering::Relaxed) >= current_window.saturating_sub(1)
-        });
+        Self::evict_stale(&mut buckets, current_window);
     }
 
     /// Checks rate limit for the caller. Returns `Ok(())` if allowed, `Err` if exceeded.
@@ -226,6 +328,16 @@ impl RateLimitInterceptor {
             }
             return Ok(());
         }
+        if buckets.len() >= self.config.max_buckets {
+            // Try to reclaim capacity from stale windows before rejecting.
+            Self::evict_stale(&mut buckets, current_window);
+            if buckets.len() >= self.config.max_buckets {
+                return Err(A2aError::internal(format!(
+                    "rate limiter caller capacity exhausted ({} buckets); request rejected",
+                    self.config.max_buckets
+                )));
+            }
+        }
         buckets.insert(
             key.to_string(),
             CallerBucket {
@@ -244,7 +356,7 @@ impl ServerInterceptor for RateLimitInterceptor {
         ctx: &'a CallContext,
     ) -> Pin<Box<dyn Future<Output = A2aResult<()>> + Send + 'a>> {
         Box::pin(async move {
-            let key = Self::caller_key(ctx);
+            let key = self.caller_key(ctx);
             self.check(&key).await
         })
     }
@@ -275,7 +387,9 @@ mod tests {
         let limiter = RateLimitInterceptor::new(RateLimitConfig {
             requests_per_window: 5,
             window_secs: 60,
-        });
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
         let ctx = make_ctx(Some("user-1"));
         for _ in 0..5 {
             assert!(limiter.before(&ctx).await.is_ok());
@@ -287,7 +401,9 @@ mod tests {
         let limiter = RateLimitInterceptor::new(RateLimitConfig {
             requests_per_window: 3,
             window_secs: 60,
-        });
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
         let ctx = make_ctx(Some("user-2"));
         for _ in 0..3 {
             assert!(limiter.before(&ctx).await.is_ok());
@@ -301,7 +417,9 @@ mod tests {
         let limiter = RateLimitInterceptor::new(RateLimitConfig {
             requests_per_window: 2,
             window_secs: 60,
-        });
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
         let ctx_a = make_ctx(Some("alice"));
         let ctx_b = make_ctx(Some("bob"));
 
@@ -319,36 +437,255 @@ mod tests {
         let limiter = RateLimitInterceptor::new(RateLimitConfig {
             requests_per_window: 1,
             window_secs: 60,
-        });
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
         let ctx = make_ctx(None);
         assert!(limiter.before(&ctx).await.is_ok());
         assert!(limiter.before(&ctx).await.is_err());
     }
 
+    /// Regression (D3a): by default `x-forwarded-for` is untrusted and must
+    /// NOT create per-value buckets — otherwise a caller bypasses the limit
+    /// by forging a fresh address on every request.
     #[tokio::test]
-    async fn uses_x_forwarded_for_when_no_identity() {
+    async fn default_config_ignores_forged_x_forwarded_for() {
         let limiter = RateLimitInterceptor::new(RateLimitConfig {
             requests_per_window: 1,
             window_secs: 60,
-        });
-        let mut headers = HashMap::new();
-        headers.insert(
-            "x-forwarded-for".to_string(),
-            "10.0.0.1, 10.0.0.2".to_string(),
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
+        // Two requests forging *different* client addresses must share the
+        // anonymous bucket: the second is rejected.
+        let ctx1 = CallContext::new("message/send").with_http_header("x-forwarded-for", "10.0.0.1");
+        let ctx2 = CallContext::new("message/send").with_http_header("x-forwarded-for", "10.0.0.2");
+        assert!(limiter.before(&ctx1).await.is_ok());
+        assert!(
+            limiter.before(&ctx2).await.is_err(),
+            "forged x-forwarded-for must not evade the limit"
         );
-        let ctx = CallContext::new("message/send").with_http_headers(headers);
-        assert!(limiter.before(&ctx).await.is_ok());
-        assert!(limiter.before(&ctx).await.is_err());
+        // And no per-address buckets were created.
+        assert_eq!(limiter.buckets.read().await.len(), 1);
+    }
+
+    /// With one trusted proxy hop, the caller key is the *rightmost* entry
+    /// (appended by the trusted proxy); client-supplied entries further left
+    /// must not mint fresh buckets.
+    #[tokio::test]
+    async fn trusted_hop_uses_rightmost_entry_and_resists_spoofing() {
+        let limiter = RateLimitInterceptor::new(RateLimitConfig {
+            requests_per_window: 1,
+            window_secs: 60,
+            trusted_proxy_hops: 1,
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
+        // Same real client (rightmost), different forged prefixes.
+        let ctx1 = CallContext::new("message/send")
+            .with_http_header("x-forwarded-for", "6.6.6.1, 203.0.113.7");
+        let ctx2 = CallContext::new("message/send")
+            .with_http_header("x-forwarded-for", "6.6.6.2, 203.0.113.7");
+        assert!(limiter.before(&ctx1).await.is_ok());
+        assert!(
+            limiter.before(&ctx2).await.is_err(),
+            "spoofed left-hand entries must map to the same real client"
+        );
+        // A different real client gets its own budget.
+        let ctx3 =
+            CallContext::new("message/send").with_http_header("x-forwarded-for", "203.0.113.8");
+        assert!(limiter.before(&ctx3).await.is_ok());
+    }
+
+    /// With `n` trusted hops the client is the `n`-th entry from the right.
+    #[tokio::test]
+    async fn trusted_hops_two_takes_second_from_right() {
+        let limiter = RateLimitInterceptor::new(RateLimitConfig {
+            requests_per_window: 1,
+            window_secs: 60,
+            trusted_proxy_hops: 2,
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
+        // XFF: [forged, client, proxy1] — client is 2nd from the right.
+        let ctx1 = CallContext::new("message/send")
+            .with_http_header("x-forwarded-for", "6.6.6.1, 198.51.100.9, 10.0.0.5");
+        let ctx2 = CallContext::new("message/send")
+            .with_http_header("x-forwarded-for", "6.6.6.2, 198.51.100.9, 10.0.0.5");
+        assert!(limiter.before(&ctx1).await.is_ok());
+        assert!(
+            limiter.before(&ctx2).await.is_err(),
+            "same client, same bucket"
+        );
+    }
+
+    /// A request with fewer XFF entries than trusted hops did not traverse the
+    /// expected proxy chain: it falls back to the shared anonymous bucket.
+    #[tokio::test]
+    async fn short_xff_chain_falls_back_to_anonymous() {
+        let limiter = RateLimitInterceptor::new(RateLimitConfig {
+            requests_per_window: 1,
+            window_secs: 60,
+            trusted_proxy_hops: 3,
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
+        let ctx1 = CallContext::new("message/send").with_http_header("x-forwarded-for", "1.2.3.4");
+        let ctx2 = CallContext::new("message/send").with_http_header("x-forwarded-for", "5.6.7.8");
+        assert!(limiter.before(&ctx1).await.is_ok());
+        assert!(
+            limiter.before(&ctx2).await.is_err(),
+            "short chains must share the anonymous bucket, not be trusted"
+        );
+    }
+
+    // ── Constructor validation (D3c) ───────────────────────────────────────
+
+    /// Regression (D3c): `window_secs == 0` previously panicked with a
+    /// divide-by-zero on the first request; it must be rejected up front.
+    #[test]
+    fn new_rejects_zero_window_secs() {
+        let err = RateLimitInterceptor::new(RateLimitConfig {
+            window_secs: 0,
+            ..RateLimitConfig::default()
+        })
+        .expect_err("zero window_secs must be rejected");
+        assert!(err.to_string().contains("window_secs"), "got: {err}");
+    }
+
+    #[test]
+    fn new_rejects_zero_requests_per_window() {
+        let err = RateLimitInterceptor::new(RateLimitConfig {
+            requests_per_window: 0,
+            ..RateLimitConfig::default()
+        })
+        .expect_err("zero requests_per_window must be rejected");
+        assert!(
+            err.to_string().contains("requests_per_window"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn new_rejects_zero_max_buckets() {
+        let err = RateLimitInterceptor::new(RateLimitConfig {
+            max_buckets: 0,
+            ..RateLimitConfig::default()
+        })
+        .expect_err("zero max_buckets must be rejected");
+        assert!(err.to_string().contains("max_buckets"), "got: {err}");
+    }
+
+    // ── Bounded bucket map (D3b) ───────────────────────────────────────────
+
+    /// Regression (D3b): the bucket map must never exceed `max_buckets`; a
+    /// new caller beyond capacity is rejected (fail-closed).
+    #[tokio::test]
+    async fn bucket_map_is_bounded() {
+        let limiter = RateLimitInterceptor::new(RateLimitConfig {
+            requests_per_window: 10,
+            window_secs: 60,
+            max_buckets: 2,
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
+        assert!(limiter.before(&make_ctx(Some("a"))).await.is_ok());
+        assert!(limiter.before(&make_ctx(Some("b"))).await.is_ok());
+        let err = limiter
+            .before(&make_ctx(Some("c")))
+            .await
+            .expect_err("third caller must be rejected at capacity");
+        assert!(err.to_string().contains("capacity"), "got: {err}");
+        assert_eq!(limiter.buckets.read().await.len(), 2);
+        // Existing callers keep working at capacity.
+        assert!(limiter.before(&make_ctx(Some("a"))).await.is_ok());
+    }
+
+    /// When the map is full but holds stale (old-window) buckets, capacity is
+    /// reclaimed inline and the new caller is admitted.
+    #[tokio::test]
+    async fn full_map_evicts_stale_buckets_before_rejecting() {
+        let limiter = RateLimitInterceptor::new(RateLimitConfig {
+            requests_per_window: 10,
+            window_secs: 60,
+            max_buckets: 2,
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
+        // One live bucket + one ancient bucket fills the map.
+        assert!(limiter.before(&make_ctx(Some("live"))).await.is_ok());
+        {
+            let mut buckets = limiter.buckets.write().await;
+            buckets.insert(
+                "ancient".to_string(),
+                CallerBucket {
+                    window_start: AtomicU64::new(0),
+                    count: AtomicU64::new(1),
+                },
+            );
+        }
+        // A new caller triggers inline eviction of the stale bucket.
+        assert!(
+            limiter.before(&make_ctx(Some("newcomer"))).await.is_ok(),
+            "stale bucket should be evicted to admit the new caller"
+        );
+        let buckets = limiter.buckets.read().await;
+        assert!(!buckets.contains_key("ancient"));
+        assert!(buckets.contains_key("live"));
+        assert!(buckets.contains_key("newcomer"));
+        drop(buckets);
+    }
+
+    /// Concurrency: with many distinct callers racing, the map never exceeds
+    /// `max_buckets` and exactly `max_buckets` callers are admitted.
+    #[tokio::test]
+    async fn concurrent_distinct_callers_respect_bucket_cap() {
+        use std::sync::Arc;
+
+        let limiter = RateLimitInterceptor::new(RateLimitConfig {
+            requests_per_window: 10,
+            window_secs: 60,
+            max_buckets: 10,
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
+        let limiter = Arc::new(limiter);
+
+        let mut handles = Vec::new();
+        for i in 0..50 {
+            let lim = Arc::clone(&limiter);
+            handles.push(tokio::spawn(async move {
+                let ctx =
+                    CallContext::new("message/send").with_caller_identity(format!("user-{i}"));
+                lim.before(&ctx).await
+            }));
+        }
+
+        let mut ok_count = 0;
+        let mut err_count = 0;
+        for handle in handles {
+            match handle.await.unwrap() {
+                Ok(()) => ok_count += 1,
+                Err(_) => err_count += 1,
+            }
+        }
+        assert_eq!(ok_count, 10, "exactly max_buckets callers admitted");
+        assert_eq!(err_count, 40);
+        assert_eq!(limiter.buckets.read().await.len(), 10);
     }
 
     #[tokio::test]
     async fn concurrent_rate_limit_checks() {
         use std::sync::Arc;
 
-        let limiter = Arc::new(RateLimitInterceptor::new(RateLimitConfig {
-            requests_per_window: 100,
-            window_secs: 60,
-        }));
+        let limiter = Arc::new(
+            RateLimitInterceptor::new(RateLimitConfig {
+                requests_per_window: 100,
+                window_secs: 60,
+                ..RateLimitConfig::default()
+            })
+            .expect("valid config"),
+        );
 
         // Spawn 200 concurrent requests from the same caller.
         let mut handles = Vec::new();
@@ -380,7 +717,9 @@ mod tests {
         let limiter = RateLimitInterceptor::new(RateLimitConfig {
             requests_per_window: 10,
             window_secs: 60,
-        });
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
 
         // Create some buckets.
         let ctx_a = make_ctx(Some("stale-a"));
@@ -404,7 +743,9 @@ mod tests {
         let limiter = RateLimitInterceptor::new(RateLimitConfig {
             requests_per_window: 42,
             window_secs: 10,
-        });
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
         let debug = format!("{limiter:?}");
         assert!(
             debug.contains("RateLimitInterceptor"),
@@ -427,7 +768,7 @@ mod tests {
     /// Covers lines 250-255 (after hook returns Ok).
     #[tokio::test]
     async fn after_hook_is_noop() {
-        let limiter = RateLimitInterceptor::new(RateLimitConfig::default());
+        let limiter = RateLimitInterceptor::new(RateLimitConfig::default()).expect("valid config");
         let ctx = make_ctx(Some("user"));
         let result = limiter.after(&ctx).await;
         assert_eq!(result.unwrap(), (), "after hook should return Ok(())");
@@ -438,7 +779,9 @@ mod tests {
         let limiter = RateLimitInterceptor::new(RateLimitConfig {
             requests_per_window: 10,
             window_secs: 60,
-        });
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
 
         // 0 seconds → window 0
         assert_eq!(limiter.window_number(0), 0);
@@ -457,7 +800,9 @@ mod tests {
         let limiter = RateLimitInterceptor::new(RateLimitConfig {
             requests_per_window: 100,
             window_secs: 60,
-        });
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
 
         // Manually insert a bucket with an ancient window.
         {
@@ -486,7 +831,9 @@ mod tests {
         let limiter = RateLimitInterceptor::new(RateLimitConfig {
             requests_per_window: 10000,
             window_secs: 60,
-        });
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
 
         // Insert a stale bucket manually.
         {
@@ -528,7 +875,9 @@ mod tests {
         let limiter = RateLimitInterceptor::new(RateLimitConfig {
             requests_per_window: 2,
             window_secs: 60,
-        });
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
 
         let ctx = make_ctx(Some("race-user"));
         // First request creates the bucket.
@@ -546,7 +895,9 @@ mod tests {
         let limiter = RateLimitInterceptor::new(RateLimitConfig {
             requests_per_window: 10,
             window_secs: 60,
-        });
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
 
         // Manually insert a bucket with an old window_start so that the
         // slow-path re-check finds it with a stale window.
@@ -593,7 +944,9 @@ mod tests {
         let limiter = RateLimitInterceptor::new(RateLimitConfig {
             requests_per_window: 1,
             window_secs: 60,
-        });
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
 
         let now_secs = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -629,7 +982,9 @@ mod tests {
         let limiter = RateLimitInterceptor::new(RateLimitConfig {
             requests_per_window: 2,
             window_secs: 60,
-        });
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
 
         // First two requests create and use the fast-path bucket.
         let ctx = make_ctx(Some("fast-path-user"));
@@ -655,7 +1010,9 @@ mod tests {
         let limiter = RateLimitInterceptor::new(RateLimitConfig {
             requests_per_window: 1,
             window_secs: 60,
-        });
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
 
         let key = "fast-path-window-advance";
         // Manually insert a bucket with an old window so the fast-path CAS fires.
@@ -703,7 +1060,9 @@ mod tests {
         let limiter = RateLimitInterceptor::new(RateLimitConfig {
             requests_per_window: 10000,
             window_secs: 60,
-        });
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
 
         // Insert a stale bucket before any calls.
         {
@@ -733,13 +1092,17 @@ mod tests {
         );
     }
 
-    /// Covers the `caller_key` function with an empty x-forwarded-for (no commas).
+    /// Covers `caller_key` with a single-entry x-forwarded-for behind one
+    /// trusted hop (no commas).
     #[tokio::test]
-    async fn x_forwarded_for_single_ip() {
+    async fn x_forwarded_for_single_ip_with_trusted_hop() {
         let limiter = RateLimitInterceptor::new(RateLimitConfig {
             requests_per_window: 1,
             window_secs: 60,
-        });
+            trusted_proxy_hops: 1,
+            ..RateLimitConfig::default()
+        })
+        .expect("valid config");
         let mut headers = HashMap::new();
         headers.insert("x-forwarded-for".to_string(), "192.168.1.1".to_string());
         let ctx = CallContext::new("message/send").with_http_headers(headers);

--- a/crates/a2a-protocol-server/tests/audit_tests/public_api.rs
+++ b/crates/a2a-protocol-server/tests/audit_tests/public_api.rs
@@ -150,7 +150,7 @@ fn artifact_new_empty_parts_panics_in_debug() {
 #[test]
 fn push_config_new_construction() {
     let config = TaskPushNotificationConfig::new("task-42", "https://hooks.example.com/notify");
-    assert_eq!(config.task_id, "task-42");
+    assert_eq!(config.task_id.as_deref(), Some("task-42"));
     assert_eq!(config.url, "https://hooks.example.com/notify");
     assert!(config.id.is_none(), "id should default to None");
     assert!(config.tenant.is_none(), "tenant should default to None");

--- a/crates/a2a-protocol-server/tests/hardening_tests/push_config_store.rs
+++ b/crates/a2a-protocol-server/tests/hardening_tests/push_config_store.rs
@@ -25,7 +25,7 @@ async fn push_config_store_crud_lifecycle() {
         .expect("get")
         .expect("should be Some");
     assert_eq!(fetched.url, "https://example.com/hook");
-    assert_eq!(fetched.task_id, "task-1");
+    assert_eq!(fetched.task_id.as_deref(), Some("task-1"));
 
     // List.
     let configs = store.list("task-1").await.expect("list");

--- a/crates/a2a-protocol-server/tests/jsonrpc_edge_tests.rs
+++ b/crates/a2a-protocol-server/tests/jsonrpc_edge_tests.rs
@@ -160,6 +160,51 @@ async fn jsonrpc_id_null_is_valid() {
     assert!(v["id"].is_null());
 }
 
+/// Regression (D2): an explicit `"id": null` request is a *call* — the
+/// response must carry a present, null `id` member. (`v["id"].is_null()`
+/// alone cannot distinguish a present null from an absent member.)
+#[tokio::test]
+async fn jsonrpc_null_id_call_gets_response_with_present_null_id() {
+    let addr = start_jsonrpc_server().await;
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "ListTasks",
+        "id": null,
+        "params": {}
+    });
+    let (status, resp) = post_jsonrpc(addr, &body.to_string()).await;
+    assert_eq!(status, 200);
+    let v: serde_json::Value = serde_json::from_str(&resp).unwrap();
+    let obj = v.as_object().expect("response is an object");
+    assert!(
+        obj.contains_key("id"),
+        "null-id call must be answered with a present id member: {resp}"
+    );
+    assert!(obj["id"].is_null(), "response id must be null: {resp}");
+    assert!(obj.contains_key("result"), "expected success: {resp}");
+}
+
+/// End-to-end pin (D2): the HTTP dispatch treats every A2A request as a
+/// call — an id-less request is still answered, with a null response id
+/// (A2A defines no notification methods). This preserves long-standing
+/// behavior; the type layer now distinguishes the two states so the request
+/// round-trips faithfully.
+#[tokio::test]
+async fn jsonrpc_absent_id_request_answered_with_null_id() {
+    let addr = start_jsonrpc_server().await;
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "ListTasks",
+        "params": {}
+    });
+    let (status, resp) = post_jsonrpc(addr, &body.to_string()).await;
+    assert_eq!(status, 200);
+    let v: serde_json::Value = serde_json::from_str(&resp).unwrap();
+    let obj = v.as_object().expect("response is an object");
+    assert!(obj["id"].is_null(), "got: {resp}");
+    assert!(obj.contains_key("result"), "expected success: {resp}");
+}
+
 #[tokio::test]
 async fn jsonrpc_id_large_integer_is_valid() {
     let addr = start_jsonrpc_server().await;

--- a/crates/a2a-protocol-server/tests/postgres_store_tests.rs
+++ b/crates/a2a-protocol-server/tests/postgres_store_tests.rs
@@ -123,7 +123,7 @@ fn make_task(id: &str, context_id: &str) -> Task {
 
 fn make_push_config(task_id: &str) -> TaskPushNotificationConfig {
     TaskPushNotificationConfig {
-        task_id: task_id.to_string(),
+        task_id: Some(task_id.to_string()),
         id: None,
         tenant: None,
         url: "https://example.com/push".to_string(),
@@ -367,7 +367,7 @@ async fn push_set_get_list_delete() -> A2aResult<()> {
     let id = config.id.clone().expect("id auto-generated");
     let got = store.get("t1", &id).await?;
     assert!(got.is_some());
-    assert_eq!(got.unwrap().task_id, "t1");
+    assert_eq!(got.unwrap().task_id.as_deref(), Some("t1"));
 
     // missing
     assert!(store.get("t1", "nope").await?.is_none());

--- a/crates/a2a-protocol-server/tests/push_sender_tests.rs
+++ b/crates/a2a-protocol-server/tests/push_sender_tests.rs
@@ -206,7 +206,7 @@ async fn bearer_auth_header_is_sent() {
     let mut config = base_config(&url);
     config.authentication = Some(AuthenticationInfo {
         scheme: "bearer".into(),
-        credentials: "my-secret-token".into(),
+        credentials: Some("my-secret-token".into()),
     });
 
     sender.send(&url, &status_event(), &config).await.unwrap();
@@ -239,7 +239,7 @@ async fn basic_auth_header_is_sent() {
     let mut config = base_config(&url);
     config.authentication = Some(AuthenticationInfo {
         scheme: "basic".into(),
-        credentials: "dXNlcjpwYXNz".into(),
+        credentials: Some("dXNlcjpwYXNz".into()),
     });
 
     sender.send(&url, &status_event(), &config).await.unwrap();
@@ -295,7 +295,7 @@ async fn both_auth_and_token_headers_are_sent() {
     let mut config = base_config(&url);
     config.authentication = Some(AuthenticationInfo {
         scheme: "bearer".into(),
-        credentials: "token-123".into(),
+        credentials: Some("token-123".into()),
     });
     config.token = Some("notif-456".into());
 

--- a/crates/a2a-protocol-server/tests/sqlite_store_tests.rs
+++ b/crates/a2a-protocol-server/tests/sqlite_store_tests.rs
@@ -142,7 +142,7 @@ async fn new_push_store() -> SqlitePushConfigStore {
 
 fn make_push_config(task_id: &str) -> TaskPushNotificationConfig {
     TaskPushNotificationConfig {
-        task_id: task_id.to_string(),
+        task_id: Some(task_id.to_string()),
         id: None,
         tenant: None,
         url: "https://example.com/push".to_string(),
@@ -159,7 +159,7 @@ async fn push_set_and_get() -> A2aResult<()> {
 
     let got = store.get("t1", id).await?;
     assert!(got.is_some());
-    assert_eq!(got.unwrap().task_id, "t1");
+    assert_eq!(got.unwrap().task_id.as_deref(), Some("t1"));
     Ok(())
 }
 

--- a/crates/a2a-protocol-server/tests/tenant_sqlite_push_config_tests.rs
+++ b/crates/a2a-protocol-server/tests/tenant_sqlite_push_config_tests.rs
@@ -15,7 +15,7 @@ use a2a_protocol_types::push::TaskPushNotificationConfig;
 fn make_config(task_id: &str, id: Option<&str>, url: &str) -> TaskPushNotificationConfig {
     TaskPushNotificationConfig {
         tenant: None,
-        task_id: task_id.to_string(),
+        task_id: Some(task_id.to_string()),
         id: id.map(String::from),
         url: url.to_string(),
         token: None,
@@ -49,13 +49,13 @@ async fn set_and_get_roundtrip() {
     TenantContext::scope("t1", async {
         let saved = store.set(config).await.unwrap();
         assert_eq!(saved.id.as_deref(), Some("cfg-1"));
-        assert_eq!(saved.task_id, "task-1");
+        assert_eq!(saved.task_id.as_deref(), Some("task-1"));
         assert_eq!(saved.url, "https://example.com/hook");
 
         let got = store.get("task-1", "cfg-1").await.unwrap();
         assert!(got.is_some());
         let got = got.unwrap();
-        assert_eq!(got.task_id, "task-1");
+        assert_eq!(got.task_id.as_deref(), Some("task-1"));
         assert_eq!(got.id.as_deref(), Some("cfg-1"));
         assert_eq!(got.url, "https://example.com/hook");
     })

--- a/crates/a2a-protocol-server/tests/tenant_store_tests.rs
+++ b/crates/a2a-protocol-server/tests/tenant_store_tests.rs
@@ -217,7 +217,7 @@ fn make_push_config(task_id: &str) -> TaskPushNotificationConfig {
     TaskPushNotificationConfig {
         tenant: None,
         id: None,
-        task_id: task_id.to_owned(),
+        task_id: Some(task_id.to_owned()),
         url: "http://example.com/webhook".to_owned(),
         token: Some("secret".to_owned()),
         authentication: None,

--- a/crates/a2a-protocol-types/src/jsonrpc.rs
+++ b/crates/a2a-protocol-types/src/jsonrpc.rs
@@ -75,26 +75,110 @@ impl<'de> Deserialize<'de> for JsonRpcVersion {
 
 // ── JsonRpcId ─────────────────────────────────────────────────────────────────
 
-/// A JSON-RPC 2.0 request/response identifier.
+/// A JSON-RPC 2.0 *response* identifier.
 ///
-/// Per spec, valid values are a string, a number, or `null`. When the field is
-/// absent entirely (notifications), represent as `None`.
+/// Per spec, a response always carries an `id` member: the value of the
+/// request's id, or `null` when the request id could not be determined.
+/// `None` serializes as `null`.
 pub type JsonRpcId = Option<serde_json::Value>;
+
+// ── JsonRpcRequestId ──────────────────────────────────────────────────────────
+
+/// A JSON-RPC 2.0 *request* identifier with three distinct states.
+///
+/// JSON-RPC 2.0 distinguishes an **absent** `id` member (the request is a
+/// *notification* — no response is expected) from an **explicit `null`** id
+/// (a call — discouraged by the spec, but a call nonetheless, answered with a
+/// null-id response). Modeling the id as `Option<Value>` collapses these two
+/// states, so an explicit `"id": null` would round-trip into a notification.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum JsonRpcRequestId {
+    /// The `id` member was absent: the request is a notification.
+    #[default]
+    Absent,
+    /// The `id` member was an explicit `null`: a call with a null id.
+    Null,
+    /// A string or number id. (Kept permissive as a raw JSON value, matching
+    /// the previous behavior of accepting any JSON type here.)
+    Value(serde_json::Value),
+}
+
+impl JsonRpcRequestId {
+    /// Returns `true` when the `id` member is absent (a notification).
+    #[must_use]
+    pub const fn is_absent(&self) -> bool {
+        matches!(self, Self::Absent)
+    }
+
+    /// Returns the id value, if this is a [`Self::Value`].
+    #[must_use]
+    pub const fn as_value(&self) -> Option<&serde_json::Value> {
+        match self {
+            Self::Value(v) => Some(v),
+            Self::Absent | Self::Null => None,
+        }
+    }
+
+    /// Converts to the id a *response* to this request must carry:
+    /// the request value, or `null` for a null-id call.
+    ///
+    /// A notification ([`Self::Absent`]) expects no response at all; callers
+    /// that respond anyway (as this SDK's HTTP dispatch does, treating every
+    /// A2A request as a call) get `null`, mirroring the spec's rule for
+    /// requests whose id could not be determined.
+    #[must_use]
+    pub fn to_response_id(&self) -> JsonRpcId {
+        match self {
+            Self::Absent | Self::Null => None,
+            Self::Value(v) => Some(v.clone()),
+        }
+    }
+}
+
+impl From<serde_json::Value> for JsonRpcRequestId {
+    fn from(value: serde_json::Value) -> Self {
+        match value {
+            serde_json::Value::Null => Self::Null,
+            v => Self::Value(v),
+        }
+    }
+}
+
+impl Serialize for JsonRpcRequestId {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            // `Absent` is skipped at the struct level via
+            // `skip_serializing_if`; if serialized directly anyway, `null`
+            // is the closest JSON representation.
+            Self::Absent | Self::Null => serializer.serialize_none(),
+            Self::Value(v) => v.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for JsonRpcRequestId {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // Only reached when the `id` member is present (an absent member
+        // falls back to `#[serde(default)]` → `Absent`).
+        Ok(Self::from(serde_json::Value::deserialize(deserializer)?))
+    }
+}
 
 // ── JsonRpcRequest ────────────────────────────────────────────────────────────
 
 /// A JSON-RPC 2.0 request object.
 ///
-/// When `id` is `None`, the request is a *notification* and no response is
-/// expected.
+/// When `id` is [`JsonRpcRequestId::Absent`], the request is a *notification*
+/// and no response is expected. An explicit `"id": null` is preserved as
+/// [`JsonRpcRequestId::Null`] (a call).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JsonRpcRequest {
     /// Protocol version — always `"2.0"`.
     pub jsonrpc: JsonRpcVersion,
 
-    /// Request identifier; `None` for notifications.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: JsonRpcId,
+    /// Request identifier; [`JsonRpcRequestId::Absent`] for notifications.
+    #[serde(default, skip_serializing_if = "JsonRpcRequestId::is_absent")]
+    pub id: JsonRpcRequestId,
 
     /// A2A method name (e.g. `"message/send"`).
     pub method: String,
@@ -110,7 +194,7 @@ impl JsonRpcRequest {
     pub fn new(id: serde_json::Value, method: impl Into<String>) -> Self {
         Self {
             jsonrpc: JsonRpcVersion,
-            id: Some(id),
+            id: JsonRpcRequestId::from(id),
             method: method.into(),
             params: None,
         }
@@ -125,7 +209,7 @@ impl JsonRpcRequest {
     ) -> Self {
         Self {
             jsonrpc: JsonRpcVersion,
-            id: Some(id),
+            id: JsonRpcRequestId::from(id),
             method: method.into(),
             params: Some(params),
         }
@@ -136,7 +220,7 @@ impl JsonRpcRequest {
     pub fn notification(method: impl Into<String>, params: Option<serde_json::Value>) -> Self {
         Self {
             jsonrpc: JsonRpcVersion,
-            id: None,
+            id: JsonRpcRequestId::Absent,
             method: method.into(),
             params,
         }
@@ -401,7 +485,7 @@ mod tests {
     fn request_new_has_no_params() {
         let req = JsonRpcRequest::new(serde_json::json!(1), "test/method");
         assert_eq!(req.method, "test/method");
-        assert_eq!(req.id, Some(serde_json::json!(1)));
+        assert_eq!(req.id, JsonRpcRequestId::Value(serde_json::json!(1)));
         assert!(req.params.is_none());
         assert_eq!(req.jsonrpc, JsonRpcVersion);
     }
@@ -412,14 +496,14 @@ mod tests {
         let req =
             JsonRpcRequest::with_params(serde_json::json!("str-id"), "method", params.clone());
         assert_eq!(req.params, Some(params));
-        assert_eq!(req.id, Some(serde_json::json!("str-id")));
+        assert_eq!(req.id, JsonRpcRequestId::Value(serde_json::json!("str-id")));
     }
 
     #[test]
     fn notification_has_method_and_params() {
         let params = serde_json::json!({"task_id": "t1"});
         let n = JsonRpcRequest::notification("task/cancel", Some(params.clone()));
-        assert!(n.id.is_none());
+        assert!(n.id.is_absent());
         assert_eq!(n.method, "task/cancel");
         assert_eq!(n.params, Some(params));
     }
@@ -472,5 +556,87 @@ mod tests {
         assert_eq!(resp.id, Some(serde_json::json!(2)));
         assert_eq!(resp.error.code, -32600);
         assert_eq!(resp.jsonrpc, JsonRpcVersion);
+    }
+
+    // ── D2 regressions: three-state request id ────────────────────────────
+
+    /// Regression (D2): an explicit `"id": null` is a *call*, not a
+    /// notification — it must survive a round-trip. Previously
+    /// `Option<Value>` collapsed it to absent, so re-serialization dropped
+    /// the member entirely.
+    #[test]
+    fn explicit_null_id_roundtrips_as_null() {
+        let req: JsonRpcRequest =
+            serde_json::from_str(r#"{"jsonrpc":"2.0","id":null,"method":"message/send"}"#)
+                .expect("deserialize");
+        assert_eq!(req.id, JsonRpcRequestId::Null);
+        assert!(!req.id.is_absent(), "null id is a call, not a notification");
+
+        let json = serde_json::to_string(&req).expect("serialize");
+        assert!(
+            json.contains("\"id\":null"),
+            "explicit null id must be preserved on the wire: {json}"
+        );
+    }
+
+    /// An absent id (notification) stays absent through a round-trip.
+    #[test]
+    fn absent_id_roundtrips_as_absent() {
+        let req: JsonRpcRequest =
+            serde_json::from_str(r#"{"jsonrpc":"2.0","method":"task/cancel"}"#)
+                .expect("deserialize");
+        assert!(req.id.is_absent());
+
+        let json = serde_json::to_string(&req).expect("serialize");
+        assert!(
+            !json.contains("\"id\""),
+            "notification must omit id: {json}"
+        );
+    }
+
+    /// String and numeric ids round-trip unchanged.
+    #[test]
+    fn value_ids_roundtrip_unchanged() {
+        for raw in [
+            r#"{"jsonrpc":"2.0","id":7,"method":"m"}"#,
+            r#"{"jsonrpc":"2.0","id":"abc","method":"m"}"#,
+        ] {
+            let req: JsonRpcRequest = serde_json::from_str(raw).expect("deserialize");
+            assert!(req.id.as_value().is_some());
+            let json = serde_json::to_string(&req).expect("serialize");
+            assert_eq!(json, raw, "value ids must round-trip byte-identical");
+        }
+    }
+
+    #[test]
+    fn to_response_id_mapping() {
+        assert_eq!(JsonRpcRequestId::Absent.to_response_id(), None);
+        assert_eq!(JsonRpcRequestId::Null.to_response_id(), None);
+        assert_eq!(
+            JsonRpcRequestId::Value(serde_json::json!(3)).to_response_id(),
+            Some(serde_json::json!(3))
+        );
+    }
+
+    #[test]
+    fn request_id_from_value() {
+        assert_eq!(
+            JsonRpcRequestId::from(serde_json::Value::Null),
+            JsonRpcRequestId::Null
+        );
+        assert_eq!(
+            JsonRpcRequestId::from(serde_json::json!("x")),
+            JsonRpcRequestId::Value(serde_json::json!("x"))
+        );
+    }
+
+    /// `JsonRpcRequest::new` with an explicit null value behaves like the
+    /// wire form: the id serializes as `null`, not as an absent member.
+    #[test]
+    fn new_with_null_value_serializes_null_id() {
+        let req = JsonRpcRequest::new(serde_json::Value::Null, "m");
+        assert_eq!(req.id, JsonRpcRequestId::Null);
+        let json = serde_json::to_string(&req).expect("serialize");
+        assert!(json.contains("\"id\":null"), "got: {json}");
     }
 }

--- a/crates/a2a-protocol-types/src/lib.rs
+++ b/crates/a2a-protocol-types/src/lib.rs
@@ -65,8 +65,8 @@ pub use error::{A2aError, A2aResult, ErrorCode};
 pub use events::{StreamResponse, TaskArtifactUpdateEvent, TaskStatusUpdateEvent};
 pub use extensions::{AgentCardSignature, AgentExtension};
 pub use jsonrpc::{
-    JsonRpcError, JsonRpcErrorResponse, JsonRpcId, JsonRpcRequest, JsonRpcResponse,
-    JsonRpcSuccessResponse, JsonRpcVersion,
+    JsonRpcError, JsonRpcErrorResponse, JsonRpcId, JsonRpcRequest, JsonRpcRequestId,
+    JsonRpcResponse, JsonRpcSuccessResponse, JsonRpcVersion,
 };
 pub use message::{FileContent, Message, MessageId, MessageRole, Part, PartContent};
 pub use params::{

--- a/crates/a2a-protocol-types/src/message.rs
+++ b/crates/a2a-protocol-types/src/message.rs
@@ -296,8 +296,18 @@ impl<'de> serde::Deserialize<'de> for Part {
                     }
                 }
 
-                // Determine the content variant. Exactly one content field
-                // should be present per the A2A spec.
+                // Exactly one content member is allowed per the A2A spec.
+                // Reject ambiguous input instead of silently picking one and
+                // dropping the rest.
+                let content_members = usize::from(text.is_some())
+                    + usize::from(raw.is_some())
+                    + usize::from(url.is_some())
+                    + usize::from(data.is_some());
+                if content_members > 1 {
+                    return Err(de::Error::custom(
+                        "Part must contain exactly one of: text, raw, url, data",
+                    ));
+                }
                 let content = if let Some(t) = text {
                     PartContent::Text(t)
                 } else if let Some(r) = raw {
@@ -776,6 +786,51 @@ mod tests {
             result.is_err(),
             "duplicate metadata field must error: {result:?}"
         );
+    }
+
+    /// Regression (D7): a Part carrying more than one content member is
+    /// ambiguous and must be rejected — previously the deserializer silently
+    /// picked the first match (text > raw > url > data) and dropped the rest.
+    #[test]
+    fn part_deserialize_rejects_multiple_content_members() {
+        for json in [
+            r#"{"text":"a","raw":"b64"}"#,
+            r#"{"text":"a","url":"https://x.test/f"}"#,
+            r#"{"text":"a","data":{"k":1}}"#,
+            r#"{"raw":"b64","url":"https://x.test/f"}"#,
+            r#"{"raw":"b64","data":{"k":1}}"#,
+            r#"{"url":"https://x.test/f","data":{"k":1}}"#,
+            r#"{"text":"a","raw":"b64","url":"https://x.test/f","data":{"k":1}}"#,
+        ] {
+            let result: Result<Part, _> = serde_json::from_str(json);
+            let err = result.expect_err("ambiguous Part must be rejected");
+            assert!(
+                err.to_string().contains("exactly one"),
+                "error should explain the exactly-one rule, got: {err}"
+            );
+        }
+    }
+
+    /// Each single content member still deserializes fine after the
+    /// ambiguity check.
+    #[test]
+    fn part_deserialize_each_single_content_member_ok() {
+        for (json, want_variant) in [
+            (r#"{"text":"a"}"#, "text"),
+            (r#"{"raw":"b64"}"#, "raw"),
+            (r#"{"url":"https://x.test/f"}"#, "url"),
+            (r#"{"data":{"k":1}}"#, "data"),
+        ] {
+            let part: Part = serde_json::from_str(json).expect("single-member Part");
+            let matches = matches!(
+                (&part.content, want_variant),
+                (PartContent::Text(_), "text")
+                    | (PartContent::Raw(_), "raw")
+                    | (PartContent::Url(_), "url")
+                    | (PartContent::Data(_), "data")
+            );
+            assert!(matches, "wrong variant for {json}: {part:?}");
+        }
     }
 
     // ── PartVisitor::expecting test ───────────────────────────────────────

--- a/crates/a2a-protocol-types/src/push.rs
+++ b/crates/a2a-protocol-types/src/push.rs
@@ -258,7 +258,7 @@ mod tests {
     }
 
     /// Regression (D1): the canonical schema marks `taskId` optional (e.g.
-    /// a config nested in SendMessageConfiguration before the task exists) —
+    /// a config nested in `SendMessageConfiguration` before the task exists) —
     /// previously this failed with "missing field `taskId`".
     #[test]
     fn push_config_without_task_id_parses() {

--- a/crates/a2a-protocol-types/src/push.rs
+++ b/crates/a2a-protocol-types/src/push.rs
@@ -16,16 +16,18 @@ use serde::{Deserialize, Serialize};
 
 /// Authentication information used by an agent when calling a push webhook.
 ///
-/// In v1.0, this uses singular `scheme` (not `schemes`) and required
-/// `credentials`.
+/// In v1.0, this uses singular `scheme` (not `schemes`). `credentials` is
+/// optional in the canonical protocol schema — a scheme may not need an
+/// explicit credential value.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthenticationInfo {
     /// Authentication scheme (e.g. `"bearer"`).
     pub scheme: String,
 
-    /// Credential value (e.g. a static token).
-    pub credentials: String,
+    /// Optional credential value (e.g. a static token).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credentials: Option<String>,
 }
 
 // ── TaskPushNotificationConfig ──────────────────────────────────────────────
@@ -48,7 +50,14 @@ pub struct TaskPushNotificationConfig {
     pub id: Option<String>,
 
     /// The task for which push notifications are configured.
-    pub task_id: String,
+    ///
+    /// Optional in the canonical protocol schema: a config nested in
+    /// `SendMessageConfiguration` legitimately omits it (the task does not
+    /// exist yet), and servers assign it from context. A standalone
+    /// `CreateTaskPushNotificationConfig` call does require it — the server
+    /// rejects a missing task ID there with an invalid-params error.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
 
     /// HTTPS URL of the client's webhook endpoint.
     pub url: String,
@@ -69,7 +78,7 @@ impl TaskPushNotificationConfig {
         Self {
             tenant: None,
             id: None,
-            task_id: task_id.into(),
+            task_id: Some(task_id.into()),
             url: url.into(),
             token: None,
             authentication: None,
@@ -82,7 +91,9 @@ impl TaskPushNotificationConfig {
     ///
     /// Returns an error string if:
     /// - The URL is empty or uses an unsupported scheme
-    /// - The task ID is empty
+    /// - The task ID is present but empty (an *absent* task ID is valid on
+    ///   the wire; whether it is required depends on context — e.g. the
+    ///   server's `CreateTaskPushNotificationConfig` handler requires it)
     ///
     /// Note: `http` URLs are accepted for development/testing environments.
     /// Production deployments should enforce HTTPS.
@@ -96,7 +107,7 @@ impl TaskPushNotificationConfig {
                 self.url
             ));
         }
-        if self.task_id.is_empty() {
+        if self.task_id.as_deref() == Some("") {
             return Err("push notification task_id must not be empty".into());
         }
         Ok(())
@@ -119,7 +130,7 @@ mod tests {
 
         let back: TaskPushNotificationConfig = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back.url, "https://example.com/webhook");
-        assert_eq!(back.task_id, "task-1");
+        assert_eq!(back.task_id.as_deref(), Some("task-1"));
     }
 
     #[test]
@@ -127,21 +138,21 @@ mod tests {
         let cfg = TaskPushNotificationConfig {
             tenant: Some("tenant-1".into()),
             id: Some("cfg-1".into()),
-            task_id: "task-1".into(),
+            task_id: Some("task-1".into()),
             url: "https://example.com/webhook".into(),
             token: Some("secret".into()),
             authentication: Some(AuthenticationInfo {
                 scheme: "bearer".into(),
-                credentials: "my-token".into(),
+                credentials: Some("my-token".into()),
             }),
         };
         let json = serde_json::to_string(&cfg).expect("serialize");
         let back: TaskPushNotificationConfig = serde_json::from_str(&json).expect("deserialize");
-        assert_eq!(back.task_id, "task-1");
+        assert_eq!(back.task_id.as_deref(), Some("task-1"));
         assert_eq!(back.url, "https://example.com/webhook");
         let auth = back.authentication.expect("authentication should be Some");
         assert_eq!(auth.scheme, "bearer");
-        assert_eq!(auth.credentials, "my-token");
+        assert_eq!(auth.credentials.as_deref(), Some("my-token"));
         assert_eq!(back.tenant.as_deref(), Some("tenant-1"));
         assert_eq!(back.id.as_deref(), Some("cfg-1"));
         assert_eq!(back.token.as_deref(), Some("secret"));
@@ -152,7 +163,7 @@ mod tests {
     #[test]
     fn push_config_new_optional_fields_are_none() {
         let cfg = TaskPushNotificationConfig::new("t1", "https://hook.test");
-        assert_eq!(cfg.task_id, "t1");
+        assert_eq!(cfg.task_id.as_deref(), Some("t1"));
         assert_eq!(cfg.url, "https://hook.test");
         assert!(cfg.tenant.is_none(), "tenant should be None");
         assert!(cfg.id.is_none(), "id should be None");
@@ -222,11 +233,69 @@ mod tests {
     fn authentication_info_roundtrip() {
         let auth = AuthenticationInfo {
             scheme: "api-key".into(),
-            credentials: "secret-123".into(),
+            credentials: Some("secret-123".into()),
         };
         let json = serde_json::to_string(&auth).expect("serialize");
         let back: AuthenticationInfo = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(back.scheme, "api-key");
-        assert_eq!(back.credentials, "secret-123");
+        assert_eq!(back.credentials.as_deref(), Some("secret-123"));
+    }
+
+    // ── D1 regressions: spec-optional fields ──────────────────────────────
+
+    /// Regression (D1): the canonical schema marks `credentials` optional —
+    /// `{"scheme":"Bearer"}` previously failed with "missing field
+    /// `credentials`".
+    #[test]
+    fn authentication_info_without_credentials_parses() {
+        let auth: AuthenticationInfo =
+            serde_json::from_str(r#"{"scheme":"Bearer"}"#).expect("credentials is optional");
+        assert_eq!(auth.scheme, "Bearer");
+        assert!(auth.credentials.is_none());
+        // Round-trip: an absent credentials field stays absent.
+        let json = serde_json::to_string(&auth).expect("serialize");
+        assert_eq!(json, r#"{"scheme":"Bearer"}"#);
+    }
+
+    /// Regression (D1): the canonical schema marks `taskId` optional (e.g.
+    /// a config nested in SendMessageConfiguration before the task exists) —
+    /// previously this failed with "missing field `taskId`".
+    #[test]
+    fn push_config_without_task_id_parses() {
+        let cfg: TaskPushNotificationConfig =
+            serde_json::from_str(r#"{"url":"https://example.com/hook"}"#)
+                .expect("taskId is optional on the wire");
+        assert_eq!(cfg.url, "https://example.com/hook");
+        assert!(cfg.task_id.is_none());
+        // Round-trip: an absent taskId stays absent.
+        let json = serde_json::to_string(&cfg).expect("serialize");
+        assert_eq!(json, r#"{"url":"https://example.com/hook"}"#);
+    }
+
+    /// Wire compatibility: configs that DO carry taskId keep exact round-trip
+    /// behavior.
+    #[test]
+    fn push_config_with_task_id_roundtrips_unchanged() {
+        let input = r#"{"taskId":"task-9","url":"https://example.com/hook"}"#;
+        let cfg: TaskPushNotificationConfig = serde_json::from_str(input).expect("deserialize");
+        assert_eq!(cfg.task_id.as_deref(), Some("task-9"));
+        let json = serde_json::to_string(&cfg).expect("serialize");
+        assert_eq!(json, input);
+    }
+
+    #[test]
+    fn validate_allows_absent_task_id() {
+        let cfg = TaskPushNotificationConfig {
+            tenant: None,
+            id: None,
+            task_id: None,
+            url: "https://example.com/hook".into(),
+            token: None,
+            authentication: None,
+        };
+        assert!(
+            cfg.validate().is_ok(),
+            "absent task_id is valid on the wire"
+        );
     }
 }

--- a/crates/a2a-protocol-types/src/signing.rs
+++ b/crates/a2a-protocol-types/src/signing.rs
@@ -33,9 +33,11 @@ use crate::extensions::AgentCardSignature;
 /// Produces an RFC 8785 (JCS) canonical JSON serialization of a value.
 ///
 /// JCS defines a deterministic serialization for JSON values:
-/// - Object keys sorted lexicographically by Unicode code point
+/// - Object keys sorted lexicographically by UTF-16 code units (RFC 8785
+///   §3.2.3 — note this differs from Unicode code-point order for
+///   supplementary-plane characters such as emoji)
 /// - No insignificant whitespace
-/// - Numbers in shortest representation (no trailing zeros)
+/// - Numbers formatted per ECMAScript `Number::toString` (RFC 8785 §3.2.2)
 /// - Strings escaped per RFC 8785 rules
 ///
 /// # Errors
@@ -78,9 +80,20 @@ fn write_canonical(value: &serde_json::Value, buf: &mut Vec<u8>) -> A2aResult<()
             buf.extend_from_slice(if *b { b"true" } else { b"false" });
         }
         serde_json::Value::Number(n) => {
-            // RFC 8785: use the shortest representation.
-            let s = n.to_string();
-            buf.extend_from_slice(s.as_bytes());
+            if n.is_i64() || n.is_u64() {
+                // Integers print exactly. (All i64/u64 magnitudes are below
+                // 1e21, so ECMAScript would render them in plain integer
+                // form as well.)
+                buf.extend_from_slice(n.to_string().as_bytes());
+            } else {
+                // RFC 8785 §3.2.2: doubles use ECMAScript Number::toString
+                // formatting. serde_json's own Display differs from it
+                // (e.g. `100.0` vs `100`, `1e-6` vs `0.000001`).
+                let f = n
+                    .as_f64()
+                    .ok_or_else(|| A2aError::internal("unrepresentable JSON number"))?;
+                write_es_number(f, buf)?;
+            }
         }
         serde_json::Value::String(s) => {
             write_canonical_string(s, buf);
@@ -96,9 +109,12 @@ fn write_canonical(value: &serde_json::Value, buf: &mut Vec<u8>) -> A2aResult<()
             buf.push(b']');
         }
         serde_json::Value::Object(obj) => {
-            // RFC 8785: keys sorted by Unicode code point order.
+            // RFC 8785 §3.2.3: keys sorted by their UTF-16 code units.
+            // Plain `sort()` (code-point / UTF-8 byte order) disagrees for
+            // supplementary-plane characters: their UTF-16 surrogates
+            // (0xD800–0xDFFF) sort below BMP characters above 0xE000.
             let mut keys: Vec<&String> = obj.keys().collect();
-            keys.sort();
+            keys.sort_by(|a, b| a.encode_utf16().cmp(b.encode_utf16()));
 
             buf.push(b'{');
             for (i, key) in keys.iter().enumerate() {
@@ -113,6 +129,68 @@ fn write_canonical(value: &serde_json::Value, buf: &mut Vec<u8>) -> A2aResult<()
             }
             buf.push(b'}');
         }
+    }
+    Ok(())
+}
+
+/// Writes an `f64` using ECMAScript `Number::toString` formatting
+/// (ECMA-262 §7.1.12.1 / "`ToString` applied to the Number type"), as RFC 8785
+/// §3.2.2 requires for JSON doubles.
+///
+/// Rust's `LowerExp` produces the shortest digit string that round-trips, so
+/// it supplies the digits `s` and decimal exponent; the ECMAScript layout
+/// rules (plain integer, fixed-point, or exponential with an explicit `+`)
+/// are applied on top.
+fn write_es_number(f: f64, buf: &mut Vec<u8>) -> A2aResult<()> {
+    if f == 0.0 {
+        // Covers negative zero: ECMAScript renders -0 as "0".
+        buf.push(b'0');
+        return Ok(());
+    }
+    if f.is_sign_negative() {
+        buf.push(b'-');
+    }
+    let exp_form = format!("{:e}", f.abs()); // e.g. "9.007199254740994e15"
+    let (mantissa, exp) = exp_form
+        .split_once('e')
+        .ok_or_else(|| A2aError::internal("float LowerExp missing exponent"))?;
+    let exp: i32 = exp
+        .parse()
+        .map_err(|e| A2aError::internal(format!("float exponent parse: {e}")))?;
+    let digits: Vec<u8> = mantissa.bytes().filter(|b| *b != b'.').collect();
+    // Value = digits × 10^(n−k), with k digits and the decimal point
+    // logically after position n (ECMA-262 notation).
+    let k = i32::try_from(digits.len())
+        .map_err(|_| A2aError::internal("float digit count overflow"))?;
+    let n = exp + 1;
+
+    if k <= n && n <= 21 {
+        // Integer with (n−k) trailing zeros.
+        buf.extend_from_slice(&digits);
+        buf.extend(std::iter::repeat_n(b'0', (n - k).unsigned_abs() as usize));
+    } else if 0 < n && n <= 21 {
+        // Fixed-point with the decimal point inside the digit string.
+        buf.extend_from_slice(&digits[..n.unsigned_abs() as usize]);
+        buf.push(b'.');
+        buf.extend_from_slice(&digits[n.unsigned_abs() as usize..]);
+    } else if -6 < n && n <= 0 {
+        // Fixed-point with leading "0.000…" padding.
+        buf.extend_from_slice(b"0.");
+        buf.extend(std::iter::repeat_n(b'0', n.unsigned_abs() as usize));
+        buf.extend_from_slice(&digits);
+    } else {
+        // Exponential notation with an explicit sign on the exponent.
+        buf.push(digits[0]);
+        if digits.len() > 1 {
+            buf.push(b'.');
+            buf.extend_from_slice(&digits[1..]);
+        }
+        buf.push(b'e');
+        let e = n - 1;
+        if e >= 0 {
+            buf.push(b'+');
+        }
+        buf.extend_from_slice(e.to_string().as_bytes());
     }
     Ok(())
 }
@@ -485,5 +563,74 @@ mod tests {
             "\"\\u001f\"",
             "0x1F must be escaped as \\u001f"
         );
+    }
+
+    /// Regression (D7): RFC 8785 §3.2.3 requires key order by UTF-16 code
+    /// units, not Unicode code points. This is the RFC's own sorting example:
+    /// the emoji (U+1F600 — surrogate pair D83D DE00) must sort BEFORE
+    /// U+FB33, although its code point is higher.
+    #[test]
+    fn canonicalize_sorts_keys_by_utf16_code_units() {
+        let json = serde_json::json!({
+            "\u{20AC}": "Euro Sign",
+            "\r": "Carriage Return",
+            "\u{FB33}": "Hebrew Letter Dalet With Dagesh",
+            "1": "One",
+            "\u{1F600}": "Emoji: Grinning Face",
+            "\u{80}": "Control",
+            "\u{F6}": "Latin Small Letter O With Diaeresis"
+        });
+        let canonical = String::from_utf8(canonicalize(&json).unwrap()).unwrap();
+        let expected = concat!(
+            "{\"\\r\":\"Carriage Return\",",
+            "\"1\":\"One\",",
+            "\"\u{80}\":\"Control\",",
+            "\"\u{F6}\":\"Latin Small Letter O With Diaeresis\",",
+            "\"\u{20AC}\":\"Euro Sign\",",
+            "\"\u{1F600}\":\"Emoji: Grinning Face\",",
+            "\"\u{FB33}\":\"Hebrew Letter Dalet With Dagesh\"}"
+        );
+        assert_eq!(canonical, expected);
+    }
+
+    /// Regression (D7): RFC 8785 §3.2.2 requires ECMAScript `Number::toString`
+    /// formatting for doubles; `serde_json`'s Display differs for several
+    /// classes of values.
+    #[test]
+    fn canonicalize_numbers_use_ecmascript_formatting() {
+        let cases: &[(f64, &str)] = &[
+            (100.0, "100"),     // not "100.0"
+            (-0.0, "0"),        // not "-0.0"
+            (1e-6, "0.000001"), // not "1e-6"
+            (1e-7, "1e-7"),
+            (1e21, "1e+21"),
+            (1e20, "100000000000000000000"), // below the 1e21 cutoff
+            (0.1, "0.1"),
+            (271.828, "271.828"),
+            (-2.5e-10, "-2.5e-10"),
+            (9_007_199_254_740_994.0, "9007199254740994"), // 2^53 + 2
+            (5e-324, "5e-324"),                            // min subnormal
+            (1.797_693_134_862_315_7e308, "1.7976931348623157e+308"), // max double
+        ];
+        for (input, expected) in cases {
+            let value = serde_json::json!(input);
+            assert!(value.as_f64().is_some(), "test setup: {input} must be f64");
+            let canonical = String::from_utf8(canonicalize(&value).unwrap()).unwrap();
+            assert_eq!(&canonical, expected, "for input {input:?}");
+        }
+    }
+
+    /// Integers (i64/u64) keep their exact representation.
+    #[test]
+    fn canonicalize_integers_exact() {
+        for (value, expected) in [
+            (serde_json::json!(0), "0"),
+            (serde_json::json!(-1), "-1"),
+            (serde_json::json!(u64::MAX), "18446744073709551615"),
+            (serde_json::json!(i64::MIN), "-9223372036854775808"),
+        ] {
+            let canonical = String::from_utf8(canonicalize(&value).unwrap()).unwrap();
+            assert_eq!(canonical, expected);
+        }
     }
 }

--- a/crates/a2a-protocol-types/tests/coverage_gap_tests.rs
+++ b/crates/a2a-protocol-types/tests/coverage_gap_tests.rs
@@ -245,7 +245,7 @@ fn push_config_roundtrip() {
     assert!(json.contains("\"url\""));
 
     let back: TaskPushNotificationConfig = serde_json::from_str(&json).expect("deserialize");
-    assert_eq!(back.task_id, "task-1");
+    assert_eq!(back.task_id.as_deref(), Some("task-1"));
     assert_eq!(back.url, "https://example.com/webhook");
 }
 
@@ -254,12 +254,12 @@ fn push_config_with_auth_roundtrip() {
     let config = TaskPushNotificationConfig {
         tenant: None,
         id: Some("config-1".into()),
-        task_id: "task-1".into(),
+        task_id: Some("task-1".into()),
         url: "https://example.com/webhook".into(),
         token: Some("shared-secret".into()),
         authentication: Some(AuthenticationInfo {
             scheme: "bearer".into(),
-            credentials: "my-token".into(),
+            credentials: Some("my-token".into()),
         }),
     };
 
@@ -274,7 +274,7 @@ fn push_config_with_auth_roundtrip() {
         .as_ref()
         .expect("authentication should be present");
     assert_eq!(auth.scheme, "bearer");
-    assert_eq!(auth.credentials, "my-token");
+    assert_eq!(auth.credentials.as_deref(), Some("my-token"));
 }
 
 // ── Event types ──────────────────────────────────────────────────────────────

--- a/crates/a2a-protocol-types/tests/coverage_gap_tests.rs
+++ b/crates/a2a-protocol-types/tests/coverage_gap_tests.rs
@@ -416,7 +416,7 @@ fn jsonrpc_request_roundtrip() {
         jsonrpc: jsonrpc::JsonRpcVersion,
         method: "SendMessage".into(),
         params: Some(serde_json::json!({"test": true})),
-        id: Some(serde_json::json!(1)),
+        id: jsonrpc::JsonRpcRequestId::Value(serde_json::json!(1)),
     };
 
     let json = serde_json::to_string(&req).expect("serialize");
@@ -425,7 +425,7 @@ fn jsonrpc_request_roundtrip() {
 
     let back: JsonRpcRequest = serde_json::from_str(&json).expect("deserialize");
     assert_eq!(back.method, "SendMessage");
-    assert_eq!(back.id, Some(serde_json::json!(1)));
+    assert_eq!(back.id.as_value(), Some(&serde_json::json!(1)));
 }
 
 #[test]

--- a/crates/a2a-protocol-types/tests/signing_tests.rs
+++ b/crates/a2a-protocol-types/tests/signing_tests.rs
@@ -223,14 +223,13 @@ fn canonicalize_floating_point_number() {
 
 #[test]
 fn canonicalize_float_no_trailing_zeros() {
-    // 10.0 should be represented without unnecessary trailing zeros.
-    // serde_json represents 10.0 as a float.
+    // 10.0 must be represented without unnecessary trailing zeros.
+    // RFC 8785 §3.2.2 requires ECMAScript Number::toString formatting,
+    // which renders the integral double 10.0 as "10" (not "10.0").
     let json: serde_json::Value = serde_json::from_str("10.0").unwrap();
     let canonical = canonicalize(&json).unwrap();
     let s = String::from_utf8(canonical).unwrap();
-    // serde_json::Number::to_string for 10.0 gives "10.0" — this is the
-    // shortest faithful representation.
-    assert_eq!(s, "10.0");
+    assert_eq!(s, "10");
 }
 
 #[test]

--- a/crates/a2a-protocol-types/tests/tck_wire_format.rs
+++ b/crates/a2a-protocol-types/tests/tck_wire_format.rs
@@ -701,7 +701,7 @@ fn tck_jsonrpc_send_message_request() {
 
     let req: JsonRpcRequest = serde_json::from_value(golden).unwrap();
     assert_eq!(req.jsonrpc, JsonRpcVersion);
-    assert_eq!(req.id, Some(json!(1)));
+    assert_eq!(req.id.as_value(), Some(&json!(1)));
     assert_eq!(req.method, "SendMessage");
     let params = req.params.as_ref().expect("params should be present");
     assert!(params.get("message").is_some());

--- a/crates/a2a-protocol-types/tests/tck_wire_format.rs
+++ b/crates/a2a-protocol-types/tests/tck_wire_format.rs
@@ -957,13 +957,13 @@ fn tck_push_notification_config_wire_format() {
     });
 
     let config: TaskPushNotificationConfig = serde_json::from_value(golden).unwrap();
-    assert_eq!(config.task_id, "task-123");
+    assert_eq!(config.task_id.as_deref(), Some("task-123"));
     assert_eq!(config.url, "https://client.example.com/webhook");
     assert!(config.authentication.is_some());
 
     let auth = config.authentication.as_ref().unwrap();
     assert_eq!(auth.scheme, "bearer");
-    assert_eq!(auth.credentials, "secret-token");
+    assert_eq!(auth.credentials.as_deref(), Some("secret-token"));
 
     let ser = serde_json::to_value(&config).unwrap();
     assert_eq!(ser["taskId"], "task-123");

--- a/examples/agent-team/src/tests/basic.rs
+++ b/examples/agent-team/src/tests/basic.rs
@@ -286,12 +286,12 @@ pub async fn test_push_config_crud(ctx: &TestContext) -> TestResult {
     let push_config = TaskPushNotificationConfig {
         tenant: None,
         id: None,
-        task_id: task_id.clone(),
+        task_id: Some(task_id.clone()),
         url: webhook_url.clone(),
         token: Some("test-token-123".into()),
         authentication: Some(AuthenticationInfo {
             scheme: "bearer".into(),
-            credentials: "my-secret-bearer".into(),
+            credentials: Some("my-secret-bearer".into()),
         }),
     };
 

--- a/examples/agent-team/src/tests/coverage_gaps/axum_sqlite.rs
+++ b/examples/agent-team/src/tests/coverage_gaps/axum_sqlite.rs
@@ -403,7 +403,7 @@ pub async fn test_sqlite_push_config(ctx: &TestContext) -> TestResult {
     let config = a2a_protocol_types::push::TaskPushNotificationConfig {
         tenant: None,
         id: None,
-        task_id: task_id.clone(),
+        task_id: Some(task_id.clone()),
         url: format!("http://{}/webhook", ctx.webhook_addr),
         token: Some("sqlite-test".into()),
         authentication: None,

--- a/examples/agent-team/src/tests/dogfood.rs
+++ b/examples/agent-team/src/tests/dogfood.rs
@@ -108,7 +108,7 @@ pub async fn test_push_list_jsonrpc_regression(ctx: &TestContext) -> TestResult 
         let config = TaskPushNotificationConfig {
             tenant: None,
             id: None,
-            task_id: tid.clone(),
+            task_id: Some(tid.clone()),
             url: format!("http://{}/webhook", ctx.webhook_addr),
             token: Some(format!("regression-token-{i}")),
             authentication: None,
@@ -162,12 +162,12 @@ pub async fn test_push_event_classification(ctx: &TestContext) -> TestResult {
                 let push_config = TaskPushNotificationConfig {
                     tenant: None,
                     id: None,
-                    task_id: ev.task_id.0.clone(),
+                    task_id: Some(ev.task_id.0.clone()),
                     url: webhook_url,
                     token: Some("classify-test".into()),
                     authentication: Some(AuthenticationInfo {
                         scheme: "bearer".into(),
-                        credentials: "test-cred".into(),
+                        credentials: Some("test-cred".into()),
                     }),
                 };
                 let _ = client.set_push_config(push_config).await;

--- a/examples/agent-team/src/tests/edge_cases.rs
+++ b/examples/agent-team/src/tests/edge_cases.rs
@@ -265,7 +265,7 @@ pub async fn test_push_crud_jsonrpc(ctx: &TestContext) -> TestResult {
         let config = TaskPushNotificationConfig {
             tenant: None,
             id: None,
-            task_id: tid.clone(),
+            task_id: Some(tid.clone()),
             url: format!("http://{}/webhook", ctx.webhook_addr),
             token: Some("jsonrpc-test-token".into()),
             authentication: None,

--- a/examples/agent-team/src/tests/lifecycle.rs
+++ b/examples/agent-team/src/tests/lifecycle.rs
@@ -407,7 +407,7 @@ pub async fn test_push_not_supported(ctx: &TestContext) -> TestResult {
     let config = TaskPushNotificationConfig {
         tenant: None,
         id: None,
-        task_id: "any-task-id".to_owned(),
+        task_id: Some("any-task-id".to_owned()),
         url: format!("http://{}/webhook", ctx.webhook_addr),
         token: None,
         authentication: None,

--- a/examples/agent-team/src/tests/stress.rs
+++ b/examples/agent-team/src/tests/stress.rs
@@ -253,12 +253,12 @@ pub async fn test_push_delivery_e2e(ctx: &TestContext) -> TestResult {
                 let push_config = TaskPushNotificationConfig {
                     tenant: None,
                     id: None,
-                    task_id: ev.task_id.0.clone(),
+                    task_id: Some(ev.task_id.0.clone()),
                     url: webhook_url.clone(),
                     token: Some("e2e-push-token".into()),
                     authentication: Some(AuthenticationInfo {
                         scheme: "bearer".into(),
-                        credentials: "push-secret".into(),
+                        credentials: Some("push-secret".into()),
                     }),
                 };
                 let _ = client.set_push_config(push_config).await;


### PR DESCRIPTION
Fixes all 7 findings from the protocol audit. Every finding was reproduced empirically first, fixed minimally, and covered with regression tests that fail before / pass after. One commit per concern.

## Changes

- **D1 — push types**: `AuthenticationInfo.credentials` and `TaskPushNotificationConfig.taskId` are now `Option<String>` per the canonical schema. Server ripple handled: `on_set_push_config` rejects a missing `taskId` with a structured InvalidParams error, all five store implementations guard `None`, and the push sender skips (with a warning) the auth header when a bearer/basic scheme has no credentials. REST is unaffected (injects `taskId` from the URL path).
- **D2 — JSON-RPC id**: `JsonRpcRequest.id` is now the three-state `JsonRpcRequestId` enum (Absent/Null/Value). An explicit `"id":null` no longer collapses into a notification; all three states round-trip faithfully and a null-id call is answered with a present `"id":null`.
- **D3 — rate limiter**: `X-Forwarded-For` is ignored unless `trusted_proxy_hops` is configured (client address taken n-th from the right); the bucket map is bounded (`max_buckets`, default 10,000, with inline stale eviction); `new()` is fallible and rejects zero-value config (fixes a divide-by-zero panic on `window_secs: 0`).
- **D4 — defaults**: `max_concurrent_streams` now defaults to 1024 (was unlimited — an unauthenticated DoS vector; `usize::MAX` restores the old behavior). `executor_timeout` deliberately keeps no default — any fixed value would silently fail legitimately long-running agent tasks; it is now a documented production recommendation instead.
- **D5 — client response cap**: both HTTP transports enforce a 32 MiB default response-size cap during the read (Content-Length fast path + `Limited` for chunked bodies), configurable via `ClientBuilder::with_max_response_size`. Over-limit maps to a non-retryable error.
- **D6 — WebSocket**: the 4 MiB message cap is now enforced at the protocol level (server aborts mid-read instead of buffering under tungstenite's 64 MiB default); the client no longer leaks pending-map entries when a request times out.
- **D7 — types edge cases**: ambiguous `Part` content is rejected; RFC 8785 canonicalization sorts keys by UTF-16 code units and formats doubles per ECMAScript (`100.0`→`"100"`, `1e-6`→`"0.000001"`, `-0`→`"0"`, `1e21`→`"1e+21"`).

## Release note

D1–D4 change public API shapes or shipped defaults, warranting a minor bump (0.7.0). CHANGELOG has a full Unreleased section describing each change.

## Verification (all green at HEAD)

- Full feature matrix: workspace 1,909 / all-features 2,202 / no-default 1,909 / signing 1,954 / tracing 1,909 / tls-rustls 439 / sqlite 1,191 / postgres 1,097 / axum 1,121 — zero failures
- Clippy `-D warnings` (default + all-features), `cargo doc -D warnings`, MSRV 1.93 clippy + full suite
- TCK 20/20 on both JSON-RPC and REST
- `cargo deny check` clean; all 4 publishable crates package-verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QULKD8YZMfCx8Rf1ZMAecW

---
_Generated by [Claude Code](https://claude.ai/code/session_01QULKD8YZMfCx8Rf1ZMAecW)_