### PR TITLE
Close TCK debt; fix a mutation gate that reported success over an incomplete sweep

### DIFF
--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -8,9 +8,10 @@
 # incremental (diff-only) job instead — see the `on.schedule` cron below.
 #
 # Architecture:
-#   - Full sweep splits into 4 parallel jobs (one per library crate) to avoid
-#     the 120-minute GitHub Actions timeout.  a2a-server alone can take 100+
-#     minutes when run sequentially.
+#   - Full sweep splits into 15 parallel jobs: one each for a2a-types,
+#     a2a-client and a2a-sdk, plus 12 shards of a2a-server. Sharding exists
+#     to stay inside the 120-minute GitHub Actions job timeout; at 8 shards
+#     two of them hit it (run 30236603180, 2026-07-27) and were cancelled.
 #   - A lightweight aggregation job merges per-crate reports and produces the
 #     combined score.
 #   - Incremental mode (PRs) mutates only PR-diff changes (--in-diff) in one job.
@@ -59,9 +60,9 @@ env:
 jobs:
   # ── Per-crate mutation sweep (parallel) ──────────────────────────────────────
   #
-  # Splits the workspace into 4 parallel runners — one per library crate.
-  # This avoids the 120-minute timeout that the monolithic --workspace run hit,
-  # since a2a-server alone can generate 200-400 mutants at ~90s each.
+  # Splits the workspace across parallel runners. This avoids the 120-minute
+  # timeout that the monolithic --workspace run hit, since a2a-server alone
+  # generates > 1,800 mutants.
   #
   # When a specific package is provided via workflow_dispatch, only that
   # package's job runs (the others are skipped via the `if` condition).
@@ -79,11 +80,18 @@ jobs:
       matrix:
         # a2a-server has > 1,800 mutants and cannot finish inside a single
         # 2-hour job even at 4-way intra-crate parallelism — so we shard it
-        # across 8 separate runners (wall-clock ≈ the slowest shard; runs
-        # use nextest + a debuginfo-free profile, see mutants.toml). The `shard` value is passed verbatim to
-        # cargo-mutants' `--shard K/N` flag (cargo-mutants will split mutants
-        # deterministically across shards). Other crates run as a single
-        # shard (K=0/N=1 ≡ no sharding).
+        # across 12 separate runners. Wall-clock ≈ the slowest shard; runs
+        # use nextest + a debuginfo-free profile (see mutants.toml).
+        #
+        # It was 8, and 8 was not enough: in run 30236603180 (2026-07-27) the
+        # shards that finished took 86-113 minutes, and shards 3/8 and 4/8
+        # were cancelled at the 120-minute job timeout. 12 shards cut the
+        # per-shard load by a third, putting the slowest inside the limit
+        # with real headroom rather than four minutes of it.
+        #
+        # The `shard` value is passed verbatim to cargo-mutants' `--shard K/N`
+        # flag, which splits mutants deterministically across shards. Other
+        # crates run as a single shard (K=0/N=1 ≡ no sharding).
         include:
           - crate: a2a-protocol-types
             short: a2a-types
@@ -95,36 +103,52 @@ jobs:
             shard: "0/1"
           - crate: a2a-protocol-server
             short: a2a-server
-            name: a2a-server shard 1/8
-            shard: "0/8"
+            name: a2a-server shard 1/12
+            shard: "0/12"
           - crate: a2a-protocol-server
             short: a2a-server
-            name: a2a-server shard 2/8
-            shard: "1/8"
+            name: a2a-server shard 2/12
+            shard: "1/12"
           - crate: a2a-protocol-server
             short: a2a-server
-            name: a2a-server shard 3/8
-            shard: "2/8"
+            name: a2a-server shard 3/12
+            shard: "2/12"
           - crate: a2a-protocol-server
             short: a2a-server
-            name: a2a-server shard 4/8
-            shard: "3/8"
+            name: a2a-server shard 4/12
+            shard: "3/12"
           - crate: a2a-protocol-server
             short: a2a-server
-            name: a2a-server shard 5/8
-            shard: "4/8"
+            name: a2a-server shard 5/12
+            shard: "4/12"
           - crate: a2a-protocol-server
             short: a2a-server
-            name: a2a-server shard 6/8
-            shard: "5/8"
+            name: a2a-server shard 6/12
+            shard: "5/12"
           - crate: a2a-protocol-server
             short: a2a-server
-            name: a2a-server shard 7/8
-            shard: "6/8"
+            name: a2a-server shard 7/12
+            shard: "6/12"
           - crate: a2a-protocol-server
             short: a2a-server
-            name: a2a-server shard 8/8
-            shard: "7/8"
+            name: a2a-server shard 8/12
+            shard: "7/12"
+          - crate: a2a-protocol-server
+            short: a2a-server
+            name: a2a-server shard 9/12
+            shard: "8/12"
+          - crate: a2a-protocol-server
+            short: a2a-server
+            name: a2a-server shard 10/12
+            shard: "9/12"
+          - crate: a2a-protocol-server
+            short: a2a-server
+            name: a2a-server shard 11/12
+            shard: "10/12"
+          - crate: a2a-protocol-server
+            short: a2a-server
+            name: a2a-server shard 12/12
+            shard: "11/12"
           - crate: a2a-protocol-sdk
             short: a2a-sdk
             name: a2a-sdk
@@ -297,6 +321,72 @@ jobs:
         with:
           pattern: mutation-report-*
           path: reports/
+
+      # THE SHARD-COMPLETENESS GATE.
+      #
+      # This job aggregates whatever artifacts happen to be present and then
+      # fails only on `TOTAL_MISSED > 0`. That is unsound on its own: a shard
+      # that times out still runs its upload step, so it contributes an empty
+      # or partial `mutants.out`, `count()` reads 0 missed from it, and the
+      # aggregate reports a clean sweep over a shrunken denominator.
+      #
+      # This is not hypothetical. Run 30236603180 (2026-07-27, the first and
+      # so far only scheduled full sweep) hit exactly this: `a2a-server`
+      # shards 3/8 and 4/8 were cancelled at the 120-minute job timeout, and
+      # "Mutants Summary" still concluded **success**. Two elevenths of the
+      # workspace went unmutated and the gate said everything was caught.
+      #
+      # The incremental job below already documents this same hazard in its
+      # own header — "it gets cancelled, so the gate silently stops
+      # enforcing" — and was sharded to avoid it. The full sweep had the
+      # identical hole and no equivalent guard. This is that guard.
+      #
+      # Two independent checks, because they fail differently: a shard can
+      # end non-success (timeout/failure/cancel), or its artifact can go
+      # missing while the job still reports success.
+      - name: Require every shard to have completed
+        env:
+          # Matrix result: 'success' only when every matrix job succeeded.
+          SHARD_RESULT: ${{ needs.mutants-crate.result }}
+          # Must equal the number of `include:` entries in mutants-crate
+          # (12 a2a-server shards + types + client + sdk). Deliberately a
+          # literal: if the matrix grows and this does not, the sweep fails
+          # loudly here rather than quietly measuring less.
+          EXPECTED_SHARDS: 15
+          # A workflow_dispatch scoped to one package skips the other matrix
+          # entries by design, so they legitimately upload nothing. Only the
+          # unscoped sweep — the one whose score means "the whole workspace" —
+          # is held to the full count.
+          PACKAGE_FILTER: ${{ inputs.package }}
+        run: |
+          fail=0
+
+          if [ "$SHARD_RESULT" != "success" ]; then
+            echo "::error::mutation shards did not all succeed (matrix result: ${SHARD_RESULT})."
+            echo "A cancelled or timed-out shard produces an empty report, which this"
+            echo "job would otherwise aggregate as 'zero surviving mutants'."
+            fail=1
+          fi
+
+          found=$(find reports -maxdepth 1 -type d -name 'mutation-report-*' | wc -l)
+          if [ -n "$PACKAGE_FILTER" ]; then
+            echo "Scoped run (package='${PACKAGE_FILTER}'): ${found} report(s); count not enforced."
+          elif [ "$found" -ne "$EXPECTED_SHARDS" ]; then
+            echo "::error::expected ${EXPECTED_SHARDS} per-shard reports, found ${found}."
+            echo "Reports present:"
+            find reports -maxdepth 1 -type d -name 'mutation-report-*' -printf '  %f\n' | sort
+            fail=1
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            echo ""
+            echo "The sweep is incomplete, so its score is not a measurement of the"
+            echo "whole workspace. Re-run it, or raise the per-shard timeout /"
+            echo "shard count, before trusting or recording any number from it."
+            exit 1
+          fi
+
+          echo "All ${EXPECTED_SHARDS} shards completed and reported."
 
       - name: Aggregate results
         run: |

--- a/.github/workflows/official-tck.yml
+++ b/.github/workflows/official-tck.yml
@@ -120,12 +120,18 @@ jobs:
       # is. `|| true` is written here explicitly rather than via
       # `continue-on-error` so it is obvious at a glance that the next step is
       # what decides.
+      #
+      # The report is copied out immediately. Every run writes the same
+      # `reports/compatibility.json`, so the later minimal and extension runs
+      # overwrite it — without this copy, both the gate below and the uploaded
+      # artifact would silently describe whichever profile ran last.
       - name: Run the official suite
         working-directory: /tmp/a2a-tck
         run: |
           set -o pipefail
           ./.venv/bin/python run_tck.py --sut-host http://127.0.0.1:9999 \
             2>&1 | tee /tmp/tck-full.log || true
+          cp reports/compatibility.json /tmp/full-compatibility.json
 
       # THE GATE. Fails the job on any MUST-level failure not in the baseline,
       # and equally on any baseline entry that now passes — a baseline that is
@@ -136,7 +142,7 @@ jobs:
       - name: Gate against the conformance baseline
         run: |
           python3 tck/scripts/check_conformance.py \
-            --report /tmp/a2a-tck/reports/compatibility.json \
+            --report /tmp/full-compatibility.json \
             --baseline tck/conformance-baseline.json 2>&1 | tee /tmp/tck-gate.log
 
       - name: Summarize
@@ -214,6 +220,55 @@ jobs:
             --report /tmp/minimal-compatibility.json \
             --baseline tck/conformance-baseline.json
 
+      # A third profile, for exactly one requirement. CORE-CAP-004 asserts that
+      # a server advertising an extension with `required: true` rejects a
+      # request that does not declare support for it. Neither the full nor the
+      # minimal card declares such an extension, so under both of those the
+      # requirement records SKIPPED and is never graded.
+      #
+      # Why this run is scoped with `-k` rather than run whole:
+      # required-extension enforcement is per-request (spec §3.3.4), and this
+      # SDK implements it that way. The suite does not send `A2A-Extensions`
+      # activation on its ordinary positive requests — upstream
+      # a2aproject/a2a-tck#193, still open as of the pin in A2A_TCK_REVISION —
+      # so an unscoped run against this card answers every other CORE-* check
+      # with ExtensionSupportRequiredError. Measured, not guessed: the
+      # unscoped run produces 72 failures.
+      #
+      # This is scoping, not a waiver. Every requirement excluded here is
+      # graded by the full-profile run above, which is the one the baseline
+      # gate reads. Upstream notes other SDKs pass this requirement with a
+      # `sitecustomize.py` shim that patches the harness into sending the
+      # header; that changes the suite rather than the SUT, and is not used.
+      - name: Run the suite against the required-extension profile
+        run: |
+          SUT_PROFILE=extension SUT_HOST=127.0.0.1:9995 SUT_GRPC_HOST=127.0.0.1:9994 \
+            ./target/release/a2a-tck-sut &
+          for i in $(seq 1 30); do
+            curl -sf http://127.0.0.1:9995/.well-known/agent-card.json > /dev/null 2>&1 && break
+            sleep 1
+          done
+          cd /tmp/a2a-tck
+          suite_status=0
+          ./.venv/bin/python run_tck.py --sut-host http://127.0.0.1:9995 -- \
+            -k "TestCapabilityExtensionRequired" \
+            2>&1 | tee /tmp/tck-extension.log || suite_status=$?
+          cp reports/compatibility.json /tmp/extension-compatibility.json
+          exit "$suite_status"
+
+      # `--require-pass` is load-bearing here, not decoration. A scoped run
+      # that selects zero tests reports zero failures, which the differential
+      # gate alone would accept as success — the exact shape of green check
+      # this repo refuses to ship. Requiring CORE-CAP-004 to be graded PASS
+      # means an upstream rename of the test class turns the job red instead.
+      - name: Gate the required-extension run
+        if: always()
+        run: |
+          python3 tck/scripts/check_conformance.py \
+            --report /tmp/extension-compatibility.json \
+            --baseline tck/conformance-baseline.json \
+            --require-pass CORE-CAP-004
+
       - name: Upload TCK reports
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -223,4 +278,9 @@ jobs:
             /tmp/a2a-tck/reports/
             /tmp/tck-full.log
             /tmp/tck-gate.log
+            /tmp/tck-minimal.log
+            /tmp/tck-extension.log
+            /tmp/full-compatibility.json
+            /tmp/minimal-compatibility.json
+            /tmp/extension-compatibility.json
           if-no-files-found: ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ existing `RELEASING.md` checklist.
 
 ### Added
 
+- **`SignatureHeader` and `signature_header()` in `a2a-protocol-types`** —
+  decodes an `AgentCardSignature`'s JWS protected header, exposing `alg`,
+  `kid` and `jku` so a caller can determine *which* key to retrieve before
+  verifying. It performs no cryptographic verification, and the header is
+  attacker-controlled until `verify_agent_card` succeeds against a trusted
+  key — the docs say so at the call site. Key expiry and revocation
+  (`CARD-SIGN-004`) remain the caller's responsibility, since neither is
+  carried in the header; this provides the `jku`/`kid` needed to go and
+  check them.
+
 - **Unrecognised request parameters are now logged instead of vanishing.** The
   specification requires implementations to *ignore* unknown fields for
   forward compatibility (§11; the official TCK grades this as
@@ -373,6 +383,25 @@ not patches for the six spellings the TCK happens to send.
 
 ### Added (governance, legal, and release policy)
 
+- **Security and conduct reports now go to a reachable address.**
+  `a2a-rust.dev` is not registered — DNS returns NXDOMAIN — so both
+  `security@a2a-rust.dev` (`SECURITY.md`'s primary vulnerability channel) and
+  `conduct@a2a-rust.dev` (`CODE_OF_CONDUCT.md`'s only reporting channel) were
+  undeliverable, and anything sent to either would have bounced or been lost.
+  Both now point at the maintainer address already published in this project's
+  copyright headers, and `SECURITY.md` promotes GitHub Security Advisories to
+  the preferred channel since it stays private without a PGP key. Each file
+  states plainly that the `a2a-rust.dev` address does not work, so it is not
+  reinstated on the assumption that it does.
+- **`ROADMAP.md`** — what the repository has already committed to for 0.8
+  (three deprecation removals), the gaps in the project's own verification,
+  the supply-chain items still open (unsigned tags, no PGP key, the
+  unregistered domain), and the measured 92/114 TCK position. Derived only
+  from what is already in the tree; it asserts no dates.
+- **`SECURITY.md` release-artifact verification table** — states what is and
+  is not signed. All ten release tags are lightweight, so `git tag -v`
+  verifies nothing; adopters needing a cryptographic link to this repository
+  must use the SLSA build provenance attestations instead.
 - **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, with the four-tier
   enforcement ladder (Correction / Warning / Temporary Ban / Permanent Ban)
   and a conduct-specific reporting address. Replaces the four-line clause in

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -62,7 +62,14 @@ representative at an online or offline event.
 ## Reporting
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the project maintainers at **conduct@a2a-rust.dev**.
+reported to the maintainer at **tomf@tomtomtech.net** — the address in this
+project's copyright headers.
+
+> A dedicated `conduct@a2a-rust.dev` address is intended, but `a2a-rust.dev`
+> is not yet registered (it returns NXDOMAIN), so mail to it bounces. This
+> file previously named that address as the sole reporting channel, which
+> left the Code of Conduct with no working way to report anything. The
+> maintainer address above is used until the domain is live.
 
 All complaints will be reviewed and investigated promptly and fairly. All
 project maintainers are obligated to respect the privacy and security of the

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -68,11 +68,15 @@ This project adopts the Contributor Covenant 2.1. The full text, including the
 four-tier enforcement ladder and the reporting channel, is in
 [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
 
-Conduct reports go to **conduct@a2a-rust.dev**, not to the security address —
-those are separate processes. This section previously routed conduct reports to
-`security@a2a-rust.dev`, which conflated vulnerability disclosure with conduct
-enforcement; `CODE_OF_CONDUCT.md` is now the authoritative statement and this
-paragraph is only a pointer to it.
+Conduct reports go to the maintainer at **tomf@tomtomtech.net**, not to the
+security channel — those are separate processes. This section previously
+routed conduct reports to `security@a2a-rust.dev`, which conflated
+vulnerability disclosure with conduct enforcement; `CODE_OF_CONDUCT.md` is now
+the authoritative statement and this paragraph is only a pointer to it.
+
+The eventual `conduct@a2a-rust.dev` address is not yet usable — `a2a-rust.dev`
+is unregistered (NXDOMAIN) — so the maintainer address stands in for it. See
+[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
 
 ## Release Process
 

--- a/README.md
+++ b/README.md
@@ -366,6 +366,10 @@ standards, testing requirements, and quality gates, and
 governed by the [Code of Conduct](CODE_OF_CONDUCT.md) (Contributor Covenant
 2.1).
 
+[ROADMAP.md](ROADMAP.md) lists what is already committed for the next release
+(0.8 is a breaking one — it removes several deprecated APIs), the known gaps
+in this project's own verification, and the questions still open.
+
 Every commit must be signed off under the
 [Developer Certificate of Origin](DCO) (`git commit -s`) by a human git author;
 CI enforces this. [PROVENANCE.md](PROVENANCE.md) documents this project's use

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -79,6 +79,27 @@ git tag -a vX.Y.Z -m "Release vX.Y.Z"
 git push origin vX.Y.Z
 ```
 
+> **Known gap — the existing tags do not match this step.** All ten release
+> tags to date (`v0.2.0` … `v0.7.0`) are *lightweight*: bare refs to a commit,
+> with no tagger, no date, and no signature. `git cat-file -t v0.7.0` prints
+> `commit`, not `tag`. The `-a` above was documented but not applied in
+> practice — creating a release through the GitHub UI produces a lightweight
+> tag, which is the likely cause.
+>
+> Consequences, so nobody assumes more than is true:
+> * A tag alone does not attest who cut the release, or when.
+> * Nothing here is GPG/SSH-signed, so `git tag -v` cannot verify any release.
+> * Adopters needing a verifiable link from a version to this repository must
+>   use the build provenance attestations in [`PROVENANCE.md`](PROVENANCE.md),
+>   which *are* signed, rather than the tag.
+>
+> Using `-a` as written fixes this for future releases; it does not
+> retroactively fix the ten existing tags, and re-tagging published releases
+> would move refs that downstreams may already pin. Adopting signed tags
+> (`git tag -s`) is a separate, unmade decision — it needs a maintainer key
+> and a documented way for adopters to obtain it. Tracked in
+> [`ROADMAP.md`](ROADMAP.md).
+
 This triggers the release workflow (`.github/workflows/release.yml`) which:
 
 1. **Validates** that all 4 crate versions match the tag and CHANGELOG entry exists

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,111 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 Tom F. <tomf@tomtomtech.net> (https://github.com/tomtom215) -->
+
+# Roadmap
+
+Current release: **0.7.0**. MSRV **1.93**.
+
+## What this file is
+
+Every item below is derived from something already committed to this
+repository — a `#[deprecated]` attribute, a documented removal, a measured
+gap, a workflow that does not yet do what it claims. Nothing here is an
+invented milestone, and no dates are asserted, because sequencing and
+priority are the maintainer's call, not a thing to infer from the tree.
+
+Items are grouped by whether the work is *already decided* (0.8 removals that
+the code and docs commit to), *decided but unscheduled*, or *open questions*
+that need a maintainer decision before any work starts.
+
+## 0.8 — removals this repository has already committed to
+
+These are announced in the code and docs, so 0.8 is a breaking release
+regardless of what else lands. Each is a `#[deprecated]` attribute or an
+explicit "removal planned for 0.8" note today.
+
+| Item | Where it is announced |
+|---|---|
+| Remove the `grpc-legacy-json` feature and the pre-0.7 JSON-tunnel gRPC service it serves | `crates/README.md`, `proto/README.md`, `book/src/building-agents/dispatchers.md`, `docs/adr/0009-protobuf-native-grpc.md` |
+| Remove `with_event_queue_write_timeout` — a deprecated no-op; queue writes never block, and slow consumers get an explicit lag error | `crates/a2a-protocol-server/src/builder.rs`, `.../streaming/event_queue/manager.rs`, `book/src/reference/configuration.md`, `book/src/building-agents/handler.md` |
+| Stop sending the legacy bare `a2a-notification-token` header; keep only the canonical `X-A2A-Notification-Token` | `CHANGELOG.md` (0.7.0 entry) |
+
+Removing the legacy gRPC tunnel also deletes `dispatch/grpc/service.rs`,
+which is the file whose thin test coverage prompted the 2026-07-31 defect
+hunt. Worth sequencing so that effort is not spent twice.
+
+## Verification debt
+
+Work where the project's own gates do not yet measure what they claim to.
+This is the category most worth clearing before any external review.
+
+* **Land one complete mutation sweep.** No full sweep has ever finished. The
+  only scheduled run (2026-07-27) lost two `a2a-server` shards to the
+  120-minute job timeout while the summary job still reported success. A
+  completeness gate and 12-way sharding landed 2026-07-31; the next run is
+  the first that can produce a trustworthy number.
+  See [`book/src/reference/mutation-history.md`](book/src/reference/mutation-history.md).
+* **Record the first real mutation score**, then keep the ledger current.
+  Until a row exists, the project has no mutation-adequacy history at all.
+* **Raise coverage on the genuinely weak files.** After the 2026-07-31 pass,
+  the weakest are `handler/event_processing/background/mod.rs` (54.2%),
+  `serve.rs` (67.5%), and `background/push_delivery.rs` (72.8%). The first
+  was on the previous shortlist and is still untouched; `serve.rs` was not
+  on any list and should have been.
+* **Decide whether `A2aRouter` should route `/tenants/{tenant}/…`.** The
+  built-in REST dispatcher strips that prefix and threads the tenant
+  through; the axum adapter registers no such routes. Verified to fail
+  closed — such a request 404s rather than being served from the default
+  partition — and pinned by a test, but the asymmetry between the two
+  dispatchers is undocumented behaviour that a user will eventually hit.
+
+## Release engineering and supply chain
+
+* **Signed tags.** All ten release tags (`v0.2.0` … `v0.7.0`) are lightweight:
+  no tagger, no date, no signature, despite `RELEASING.md` prescribing
+  `git tag -a`. Adopting `git tag -s` needs a maintainer key and a documented
+  way for adopters to obtain it — an unmade decision, not just a missing
+  step. See [`RELEASING.md`](RELEASING.md).
+* **PGP key for security reports.** `SECURITY.md` has none, so emailed
+  vulnerability reports cannot be encrypted. GitHub Security Advisories is
+  the recommended channel in the meantime.
+* **Register `a2a-rust.dev`.** The domain is unregistered (NXDOMAIN), so both
+  `conduct@a2a-rust.dev` and `security@a2a-rust.dev` are undeliverable. Both
+  documents now point at the maintainer address instead; the dedicated
+  addresses can be restored once the domain is live.
+
+## Conformance
+
+Measured against the official `a2a-tck` suite: **92 of 114 MUST requirements
+passing, 0 failing.** The remaining 22 are not defects in this SDK — 21 have
+no test function upstream, and `CARD-EXT-002` is structurally inapplicable.
+Full analysis and reproduction steps in
+[`docs/official-tck-findings.md`](docs/official-tck-findings.md).
+
+* **Report `SSE-001` upstream.** A reproduction and analysis are prepared but
+  unfiled, pending a maintainer decision on whether to open the issue.
+* **Track the 13 open upstream backlog items** that would move requirements
+  out of `NOT TESTED` if `a2a-tck` implements them. Nothing to do here except
+  re-measure when upstream moves; the ceiling is not this project's to raise.
+* **WebSocket** remains a custom binding under spec §12 and is deliberately
+  outside the official suite's scope. It is covered by this repository's own
+  feature-gated tests.
+
+## Open questions
+
+Genuinely undecided — listed so they are not mistaken for oversights.
+
+* Whether to adopt signed tags at all, or to rely solely on the SLSA build
+  provenance attestations already produced for release artifacts
+  (see [`PROVENANCE.md`](PROVENANCE.md)).
+* Whether `0.8` should also raise MSRV, and what support window to state.
+* Whether the axum adapter should reach parity with the REST dispatcher on
+  tenant routing, or whether the split is intentional and should simply be
+  documented as such.
+
+## Maintaining this file
+
+Add an item when the repository commits to it — a deprecation, a documented
+removal, a measured gap. Remove it when the work lands, and say where it
+landed. Do not add speculative milestones: a roadmap that lists intentions
+nobody has committed to is worse than no roadmap, because it cannot be
+checked against anything.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,14 +27,44 @@ responsibly. **Do not open a public GitHub issue.**
 
 ### Preferred Channels
 
-1. **Email:** Send a detailed report to **security@a2a-rust.dev**.
-2. **GitHub Security Advisories:** Open a draft advisory at
-   <https://github.com/tomtom215/a2a-rust/security/advisories/new>.
+1. **GitHub Security Advisories (preferred):** Open a draft advisory at
+   <https://github.com/tomtom215/a2a-rust/security/advisories/new>. The report
+   stays private to you and the maintainers, and the channel is encrypted in
+   transit by GitHub.
+2. **Email:** Send a detailed report to **tomf@tomtomtech.net** — the address
+   in this project's copyright headers.
+
+> **`security@a2a-rust.dev` does not work.** Earlier revisions of this file
+> listed it as the primary channel, but `a2a-rust.dev` is not registered
+> (NXDOMAIN), so mail to it is undeliverable and a report sent there would
+> have been silently lost. Use one of the two channels above. The dedicated
+> address will be restored here once the domain is live.
 
 ### PGP Key
 
-PGP encryption for security reports is not yet available. For now, please
-send reports in plain text to the email address above.
+**Not available.** There is no published PGP key for this project, so reports
+sent by email cannot be encrypted end-to-end. This is a real gap for anyone
+who needs to disclose an unpatched vulnerability over untrusted mail.
+
+Until a key is published, prefer **GitHub Security Advisories** (channel 1),
+which keeps the report private without needing one. If you must use email and
+the contents are sensitive, send a short notice without details and ask for an
+encrypted channel first.
+
+### Release Artifact Verification
+
+Know what you can and cannot verify about a release:
+
+| Artifact | Signed? | How to verify |
+|---|---|---|
+| Git tags (`v0.2.0` … `v0.7.0`) | **No** | Nothing to verify. All ten release tags to date are lightweight — unannotated and unsigned — so they carry no tagger identity, no date, and no signature. A tag alone does not establish who cut the release. |
+| Release binaries / SBOMs | Yes | Attested in the release workflow; see [`PROVENANCE.md`](PROVENANCE.md). |
+| Published crates | Yes (by crates.io) | Standard crates.io registry checksums. |
+
+If you need a cryptographic link between a published version and this
+repository, use the build provenance attestations described in
+`PROVENANCE.md`, not the git tag. Signed, annotated tags are a known gap and
+have not yet been adopted.
 
 ### What to Include
 

--- a/book/src/reference/mutation-history.md
+++ b/book/src/reference/mutation-history.md
@@ -26,8 +26,47 @@ row below, dated to the run, with the commit it ran against. A clean sweep
 (zero missed) is still worth recording — "still zero" is signal too, not a
 no-op.
 
+## Why there is still no row (verified 2026-07-31)
+
+The ledger below is empty, and that is not an oversight — **no full sweep has
+ever completed.** Checked against the Actions API rather than assumed:
+
+* `mutants.yml` has exactly **one** scheduled run in its history:
+  [30236603180](https://github.com/tomtom215/a2a-rust/actions/runs/30236603180),
+  2026-07-27, against `b416c1a`. Run conclusion: `cancelled`.
+* Of its 11 sweep jobs, nine succeeded. `a2a-server` shards **3/8 and 4/8**
+  were cancelled at the 120-minute job timeout — the shards that did finish
+  took 86-113 minutes, so those two were only ever a few minutes from the
+  limit.
+* **`Mutants Summary` nonetheless concluded `success`.** A cancelled shard
+  still runs its upload step, so it contributes an empty `mutants.out`; the
+  aggregator's `count()` reads zero missed mutants from it, and the job's only
+  failure condition was `TOTAL_MISSED > 0`. Two elevenths of the workspace
+  went unmutated and the gate reported everything caught.
+
+That is the failure mode this project refuses everywhere else: a green check
+over work that did not happen. The same hazard was already understood for the
+*incremental* PR job — its header says a job that overruns "gets cancelled, so
+the gate silently stops enforcing" — but the full sweep had no equivalent
+guard.
+
+Both halves are now fixed in `mutants.yml`:
+
+1. **A shard-completeness gate** runs before aggregation and fails unless the
+   matrix result is `success` *and* the expected number of per-shard reports
+   arrived. A scoped `workflow_dispatch` (one package) is exempt from the
+   count, since it skips the other shards by design.
+2. **`a2a-server` is sharded 12 ways instead of 8**, cutting per-shard load by
+   a third so the slowest shard finishes with headroom rather than four
+   minutes to spare.
+
+So the first real row still has to come from a real, complete sweep — the next
+Monday run, or an on-demand `workflow_dispatch`. **Do not backfill a number
+from run 30236603180**: its score was computed from partial data and is not a
+measurement of the workspace.
+
 ## History
 
 | Date | Commit | Overall Score | Caught | Missed | Timeout | Notes |
 |------|--------|---------------|-------:|-------:|--------:|-------|
-| _(none recorded yet)_ | | | | | | This ledger was created 2026-07-30, retroactively, before any full sweep's result had been captured into it. The next scheduled Monday sweep (or an on-demand `workflow_dispatch` run) is the first opportunity to populate a real row — do not backfill a number that wasn't actually measured. |
+| _(none recorded yet)_ | | | | | | No full sweep has completed. The only scheduled run (2026-07-27, `b416c1a`) lost two `a2a-server` shards to the 120-minute timeout while its summary job still reported success — see the section above. The completeness gate and 12-way sharding that fix this landed 2026-07-31; the first complete sweep after that date is the first eligible row. |

--- a/crates/a2a-protocol-sdk/tests/grpc_legacy_coexistence.rs
+++ b/crates/a2a-protocol-sdk/tests/grpc_legacy_coexistence.rs
@@ -233,3 +233,159 @@ async fn canonical_and_legacy_clients_share_one_listener() {
         Some(canonical_task.id.0.as_str())
     );
 }
+
+// ── The rest of the tunnel's unary surface ──────────────────────────────────
+//
+// The test above drives SendMessage and GetTask. That left the other seven
+// unary RPCs on `a2a.v1.A2aService` — ListTasks, CancelTask, the four
+// push-notification-config methods and GetExtendedAgentCard — with no
+// coverage at all, which is why `dispatch/grpc/service.rs` measured 4/22
+// lines. They are shipping code behind the `grpc-legacy-json` feature: 0.6
+// clients still call them during a rolling upgrade, and the tunnel is not
+// removed until 0.8.
+
+/// Same fixture as above, but with push notifications and the extended card
+/// advertised so those RPCs reach their real handlers rather than a
+/// capability rejection.
+fn full_agent_card() -> AgentCard {
+    let mut card = agent_card();
+    card.capabilities = AgentCapabilities::none()
+        .with_streaming(true)
+        .with_push_notifications(true)
+        .with_extended_agent_card(true);
+    card
+}
+
+#[tokio::test]
+async fn legacy_tunnel_serves_every_unary_rpc() {
+    let handler = Arc::new(
+        RequestHandlerBuilder::new(CompletingExecutor)
+            .with_agent_card(full_agent_card())
+            .with_push_config_store(a2a_protocol_server::push::InMemoryPushConfigStore::new())
+            .with_push_sender(a2a_protocol_server::push::HttpPushSender::new())
+            .allow_unauthenticated_extended_card()
+            .build()
+            .expect("build handler"),
+    );
+    let dispatcher = GrpcDispatcher::new(handler, GrpcConfig::default());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = dispatcher.serve_with_listener(listener).expect("serve");
+    let channel = tonic::transport::Channel::from_shared(format!("http://{addr}"))
+        .expect("endpoint")
+        .connect()
+        .await
+        .expect("legacy connect");
+
+    // Seed a task through the tunnel itself.
+    let created = legacy_unary(
+        channel.clone(),
+        "/a2a.v1.A2aService/SendMessage",
+        &serde_json::to_value(send_params("seed")).expect("params"),
+    )
+    .await
+    .expect("SendMessage");
+    let task_id = created["task"]["id"].as_str().expect("task id").to_owned();
+
+    // ── ListTasks ──
+    let listed = legacy_unary(
+        channel.clone(),
+        "/a2a.v1.A2aService/ListTasks",
+        &serde_json::json!({}),
+    )
+    .await
+    .expect("ListTasks");
+    let tasks = listed["tasks"].as_array().expect("tasks array");
+    assert!(
+        tasks
+            .iter()
+            .any(|t| t["id"].as_str() == Some(task_id.as_str())),
+        "ListTasks omitted the task just created: {listed}"
+    );
+
+    // ── CreateTaskPushNotificationConfig ──
+    let created_cfg = legacy_unary(
+        channel.clone(),
+        "/a2a.v1.A2aService/CreateTaskPushNotificationConfig",
+        &serde_json::json!({ "taskId": task_id, "url": "https://example.com/hook" }),
+    )
+    .await
+    .expect("CreateTaskPushNotificationConfig");
+    let config_id = created_cfg["id"]
+        .as_str()
+        .expect("server-assigned config id")
+        .to_owned();
+
+    // ── GetTaskPushNotificationConfig ──
+    let got_cfg = legacy_unary(
+        channel.clone(),
+        "/a2a.v1.A2aService/GetTaskPushNotificationConfig",
+        &serde_json::json!({ "taskId": task_id, "id": config_id }),
+    )
+    .await
+    .expect("GetTaskPushNotificationConfig");
+    assert_eq!(
+        got_cfg["url"].as_str(),
+        Some("https://example.com/hook"),
+        "GetTaskPushNotificationConfig returned the wrong config: {got_cfg}"
+    );
+
+    // ── ListTaskPushNotificationConfigs ──
+    let listed_cfgs = legacy_unary(
+        channel.clone(),
+        "/a2a.v1.A2aService/ListTaskPushNotificationConfigs",
+        &serde_json::json!({ "taskId": task_id }),
+    )
+    .await
+    .expect("ListTaskPushNotificationConfigs");
+    assert_eq!(
+        listed_cfgs["configs"].as_array().map(Vec::len),
+        Some(1),
+        "expected exactly one config: {listed_cfgs}"
+    );
+
+    // ── DeleteTaskPushNotificationConfig ── then prove it is gone.
+    legacy_unary(
+        channel.clone(),
+        "/a2a.v1.A2aService/DeleteTaskPushNotificationConfig",
+        &serde_json::json!({ "taskId": task_id, "id": config_id }),
+    )
+    .await
+    .expect("DeleteTaskPushNotificationConfig");
+    let after_delete = legacy_unary(
+        channel.clone(),
+        "/a2a.v1.A2aService/ListTaskPushNotificationConfigs",
+        &serde_json::json!({ "taskId": task_id }),
+    )
+    .await
+    .expect("ListTaskPushNotificationConfigs after delete");
+    assert!(
+        after_delete["configs"].as_array().is_none_or(Vec::is_empty),
+        "config survived deletion over the tunnel: {after_delete}"
+    );
+
+    // ── GetExtendedAgentCard ──
+    let card = legacy_unary(
+        channel.clone(),
+        "/a2a.v1.A2aService/GetExtendedAgentCard",
+        &serde_json::json!({}),
+    )
+    .await
+    .expect("GetExtendedAgentCard");
+    assert_eq!(card["name"].as_str(), Some("Coexistence Agent"));
+
+    // ── CancelTask ── last, because it is terminal. The seeded task runs to
+    // Completed, so cancelling it must be refused rather than silently
+    // accepted: a terminal task is not cancelable.
+    let cancel = legacy_unary(
+        channel,
+        "/a2a.v1.A2aService/CancelTask",
+        &serde_json::json!({ "id": task_id }),
+    )
+    .await;
+    assert!(
+        cancel.is_err(),
+        "cancelling a completed task must fail, got: {cancel:?}"
+    );
+}

--- a/crates/a2a-protocol-server/src/dispatch/axum_adapter.rs
+++ b/crates/a2a-protocol-server/src/dispatch/axum_adapter.rs
@@ -48,6 +48,31 @@
 //!     .layer(tower_http::cors::CorsLayer::permissive())
 //!     .route("/custom", get(custom_handler));
 //! ```
+//!
+//! # Multi-tenancy: use a resolver, not the URL prefix
+//!
+//! This router registers no `/tenants/{tenant}/…` routes, unlike the built-in
+//! REST dispatcher ([`crate::dispatch::rest`]), which strips that prefix and
+//! threads the tenant through. Requests to a tenant-prefixed path therefore
+//! **404 here** — fail-safe, but surprising if you are porting from
+//! `serve()`, where the same URL works.
+//!
+//! Tenancy itself is not lost. This router forwards request headers to the
+//! handler, so a configured
+//! [`TenantResolver`](crate::tenant_resolver::TenantResolver) — for example
+//! [`HeaderTenantResolver`](crate::tenant_resolver::HeaderTenantResolver) —
+//! resolves tenants normally, and the resolver is authoritative over any
+//! client-supplied value. Pair it with
+//! [`require_resolved_tenant`](crate::RequestHandlerBuilder::require_resolved_tenant)
+//! so a request that carries no tenant is rejected rather than served from
+//! the shared default partition.
+//!
+//! With **no** resolver configured, every request through this router is
+//! served from the default (`""`) tenant, because the per-request `tenant`
+//! field is not populated from the URL. That is correct for single-tenant
+//! deployments and is the reason the prefix is absent rather than silently
+//! mis-parsed; it is called out here so it is a choice rather than a
+//! discovery.
 
 use std::collections::HashMap;
 use std::convert::Infallible;

--- a/crates/a2a-protocol-server/src/store/mod.rs
+++ b/crates/a2a-protocol-server/src/store/mod.rs
@@ -75,3 +75,81 @@ pub use pg_migration::{PgMigration, PgMigrationRunner};
 pub use postgres_store::PostgresTaskStore;
 #[cfg(feature = "postgres")]
 pub use tenant_postgres_store::TenantAwarePostgresTaskStore;
+
+#[cfg(test)]
+mod status_timestamp_tests {
+    // These two helpers had no direct tests: they were only ever exercised
+    // through the SQLite and Postgres stores, and the Postgres suite is
+    // `#[ignore]`d without a live server. `status_timestamp_sqlite` slices
+    // its formatted timestamp by byte index (`[..10]`, `[11..23]`), which is
+    // the kind of thing that is fine until an input nobody tried.
+
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_shape_is_the_column_format() {
+        assert_eq!(
+            super::status_timestamp_sqlite(Some("2026-03-15T12:00:00.123Z")).as_deref(),
+            Some("2026-03-15 12:00:00.123"),
+        );
+        // Sub-second precision is normalized to exactly three digits, because
+        // the column is compared lexicographically.
+        assert_eq!(
+            super::status_timestamp_sqlite(Some("2026-03-15T12:00:00Z")).as_deref(),
+            Some("2026-03-15 12:00:00.000"),
+        );
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_returns_none_for_missing_or_unparseable() {
+        assert_eq!(super::status_timestamp_sqlite(None), None);
+        assert_eq!(super::status_timestamp_sqlite(Some("")), None);
+        assert_eq!(
+            super::status_timestamp_sqlite(Some("not a timestamp")),
+            None
+        );
+        assert_eq!(super::status_timestamp_sqlite(Some("2026-03-15")), None);
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn sqlite_slicing_survives_out_of_range_years() {
+        // The byte slices assume a 4-digit year. A 5+-digit year makes the
+        // formatted string longer, and a pre-epoch value clamps to 1970 —
+        // neither may panic. Asserted rather than reasoned about, because a
+        // panic here aborts the process under `panic = "abort"`.
+        for input in [
+            "99999-01-01T00:00:00Z",
+            "999999-12-31T23:59:59.999Z",
+            "1969-12-31T23:59:59Z",
+            "0001-01-01T00:00:00Z",
+            "+010000-01-01T00:00:00Z",
+        ] {
+            let out = super::status_timestamp_sqlite(Some(input));
+            if let Some(s) = out {
+                assert!(
+                    s.is_char_boundary(0) && s.len() >= 23,
+                    "{input} produced a malformed value: {s:?}"
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "postgres")]
+    #[test]
+    fn rfc3339_normalizes_to_canonical_utc() {
+        assert_eq!(
+            super::status_timestamp_rfc3339(Some("2026-03-15T12:00:00.123Z")).as_deref(),
+            Some("2026-03-15T12:00:00.123Z"),
+        );
+        // Explicit offsets are normalized to UTC — stored tasks may carry
+        // timestamps written by other software (spec §5.6.1 forbids them on
+        // the wire, but the store is defensive).
+        assert_eq!(
+            super::status_timestamp_rfc3339(Some("2026-03-15T14:00:00+02:00")).as_deref(),
+            Some("2026-03-15T12:00:00.000Z"),
+        );
+        assert_eq!(super::status_timestamp_rfc3339(None), None);
+        assert_eq!(super::status_timestamp_rfc3339(Some("nope")), None);
+    }
+}

--- a/crates/a2a-protocol-server/tests/axum_adapter_tests.rs
+++ b/crates/a2a-protocol-server/tests/axum_adapter_tests.rs
@@ -366,3 +366,275 @@ async fn axum_honors_configured_body_limit() {
         "body under the configured cap should succeed (200), got {status}"
     );
 }
+
+// ── Routes that had no coverage at all ───────────────────────────────────────
+//
+// The suite above drove send/get/list/cancel and the two static endpoints,
+// which left `dispatch/axum_adapter.rs` at 61% line coverage. Everything below
+// exercises a route that was previously never reached through this adapter:
+// the four push-notification-config handlers, the extended card, streaming,
+// subscribe, and the catch-all's rejection paths.
+
+/// A server with push notifications and the extended card enabled — the
+/// default `start_test_server` advertises neither, so those routes could only
+/// ever return "unsupported" through it.
+async fn start_test_server_full() -> String {
+    let mut card = test_card();
+    card.capabilities = AgentCapabilities::none()
+        .with_streaming(true)
+        .with_push_notifications(true)
+        .with_extended_agent_card(true);
+
+    let handler = Arc::new(
+        RequestHandlerBuilder::new(EchoExecutor)
+            .with_agent_card(card)
+            .with_push_config_store(a2a_protocol_server::push::InMemoryPushConfigStore::new())
+            // A sender is required as well as a store: `validate_and_store_push_config`
+            // rejects with PushNotSupported when either is absent. Nothing is
+            // actually delivered in these tests — the task completes before a
+            // webhook would fire, and example.com is never contacted.
+            .with_push_sender(a2a_protocol_server::push::HttpPushSender::new())
+            .allow_unauthenticated_extended_card()
+            .build()
+            .expect("build handler"),
+    );
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("local addr");
+    let base_url = format!("http://{addr}");
+    let app = A2aRouter::new(handler).into_router();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    base_url
+}
+
+/// Helper: HTTP request with an arbitrary method and no body.
+async fn http_request(method: &str, url: &str) -> (u16, Bytes) {
+    let client = Client::builder(TokioExecutor::new()).build_http::<Empty<Bytes>>();
+    let req = hyper::Request::builder()
+        .method(method)
+        .uri(url)
+        .header("a2a-version", "1.0")
+        .body(Empty::<Bytes>::new())
+        .unwrap();
+    let resp = client.request(req).await.unwrap();
+    let status = resp.status().as_u16();
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    (status, body)
+}
+
+/// Sends a message and returns the resulting task id.
+async fn create_task(base: &str) -> String {
+    let (status, body) =
+        http_post_json(&format!("{base}/message:send"), &make_send_body("hi")).await;
+    assert_eq!(
+        status,
+        200,
+        "send failed: {}",
+        String::from_utf8_lossy(&body)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    v["task"]["id"]
+        .as_str()
+        .expect("task id in response")
+        .to_owned()
+}
+
+// ── Push notification config: the full CRUD cycle ────────────────────────────
+
+#[tokio::test]
+async fn axum_push_config_create_get_list_delete_round_trip() {
+    let base = start_test_server_full().await;
+    let task_id = create_task(&base).await;
+    let configs_url = format!("{base}/tasks/{task_id}/pushNotificationConfigs");
+
+    // Create. `TaskPushNotificationConfig` is flat on the wire, and `taskId`
+    // is filled in from the path by the handler when the body omits it —
+    // which this body deliberately does, so that behaviour is covered too.
+    let body = serde_json::json!({ "url": "https://example.com/webhook" }).to_string();
+    let (status, created) = http_post_json(&configs_url, &body).await;
+    assert_eq!(
+        status,
+        200,
+        "create failed: {}",
+        String::from_utf8_lossy(&created)
+    );
+    let created: serde_json::Value = serde_json::from_slice(&created).unwrap();
+    assert_eq!(
+        created["taskId"], task_id,
+        "handler must fill taskId from the path: {created}"
+    );
+    let config_id = created["id"]
+        .as_str()
+        .expect("server-assigned config id")
+        .to_owned();
+
+    // List — the config just created must be in it.
+    let (status, listed) = http_get(&configs_url).await;
+    assert_eq!(status, 200);
+    let listed: serde_json::Value = serde_json::from_slice(&listed).unwrap();
+    let arr = listed["configs"].as_array().expect("configs array");
+    assert_eq!(arr.len(), 1, "expected exactly one config, got {listed}");
+
+    // Get by id.
+    let one_url = format!("{configs_url}/{config_id}");
+    let (status, got) = http_get(&one_url).await;
+    assert_eq!(status, 200, "get failed: {}", String::from_utf8_lossy(&got));
+    let got: serde_json::Value = serde_json::from_slice(&got).unwrap();
+    assert_eq!(
+        got["url"], "https://example.com/webhook",
+        "get returned a different config: {got}"
+    );
+
+    // Delete, then confirm the list is empty — a delete that returns 200
+    // without removing anything would otherwise pass unnoticed.
+    let (status, _) = http_request("DELETE", &one_url).await;
+    assert_eq!(status, 200);
+    let (status, listed) = http_get(&configs_url).await;
+    assert_eq!(status, 200);
+    let listed: serde_json::Value = serde_json::from_slice(&listed).unwrap();
+    assert!(
+        listed["configs"].as_array().is_none_or(Vec::is_empty),
+        "config survived deletion: {listed}"
+    );
+}
+
+#[tokio::test]
+async fn axum_push_config_create_rejects_invalid_json() {
+    let base = start_test_server_full().await;
+    let task_id = create_task(&base).await;
+    let (status, _) = http_post_json(
+        &format!("{base}/tasks/{task_id}/pushNotificationConfigs"),
+        "{ not json",
+    )
+    .await;
+    assert_eq!(status, 400);
+}
+
+#[tokio::test]
+async fn axum_push_config_get_unknown_id_is_not_found() {
+    let base = start_test_server_full().await;
+    let task_id = create_task(&base).await;
+    let (status, _) = http_get(&format!(
+        "{base}/tasks/{task_id}/pushNotificationConfigs/no-such-config"
+    ))
+    .await;
+    assert_eq!(status, 404);
+}
+
+// ── Extended agent card ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn axum_extended_agent_card_is_served_when_advertised() {
+    let base = start_test_server_full().await;
+    let (status, body) = http_get(&format!("{base}/extendedAgentCard")).await;
+    assert_eq!(
+        status,
+        200,
+        "extended card failed: {}",
+        String::from_utf8_lossy(&body)
+    );
+    let card: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(card["name"], "Test Echo Agent");
+}
+
+#[tokio::test]
+async fn axum_extended_agent_card_rejected_when_not_advertised() {
+    // The default test card does not set `extendedAgentCard`, so the handler
+    // must refuse rather than serve the ordinary card from that path.
+    let base = start_test_server().await;
+    let (status, _) = http_get(&format!("{base}/extendedAgentCard")).await;
+    assert_ne!(status, 200, "unadvertised extended card must not be served");
+}
+
+// ── Streaming and subscribe ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn axum_message_stream_returns_an_sse_stream() {
+    let base = start_test_server_full().await;
+    let client = Client::builder(TokioExecutor::new()).build_http::<Full<Bytes>>();
+    let req = hyper::Request::builder()
+        .method("POST")
+        .uri(format!("{base}/message:stream"))
+        .header("content-type", "application/json")
+        .header("a2a-version", "1.0")
+        .body(Full::new(Bytes::from(make_send_body("stream me"))))
+        .unwrap();
+    let resp = client.request(req).await.unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let ctype = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_owned();
+    assert!(
+        ctype.starts_with("text/event-stream"),
+        "expected an SSE stream, got content-type {ctype:?}"
+    );
+    let body = resp.into_body().collect().await.unwrap().to_bytes();
+    let text = String::from_utf8_lossy(&body);
+    assert!(
+        text.contains("data:"),
+        "SSE body carried no events: {text:?}"
+    );
+}
+
+#[tokio::test]
+async fn axum_subscribe_to_unknown_task_is_not_found() {
+    let base = start_test_server_full().await;
+    let (status, _) = http_request("GET", &format!("{base}/tasks/no-such-task:subscribe")).await;
+    assert_eq!(status, 404);
+}
+
+// ── Catch-all dispatch: the paths that must NOT resolve ──────────────────────
+
+#[tokio::test]
+async fn axum_catchall_rejects_unknown_action_and_method() {
+    let base = start_test_server_full().await;
+    let task_id = create_task(&base).await;
+
+    // An unrecognized `:action` suffix is not a task id.
+    let (status, _) = http_request("POST", &format!("{base}/tasks/{task_id}:frobnicate")).await;
+    assert_eq!(status, 404);
+
+    // GET with a colon action is explicitly excluded from the plain-GET arm.
+    let (status, _) = http_request("GET", &format!("{base}/tasks/{task_id}:cancel")).await;
+    assert_eq!(status, 404);
+
+    // A sub-resource this adapter does not serve.
+    let (status, _) = http_request("GET", &format!("{base}/tasks/{task_id}/artifacts")).await;
+    assert_eq!(status, 404);
+
+    // Wrong method on a real route.
+    let (status, _) = http_request(
+        "DELETE",
+        &format!("{base}/tasks/{task_id}/pushNotificationConfigs"),
+    )
+    .await;
+    assert_eq!(status, 404);
+}
+
+/// Documents the tenancy contract stated in the module docs: this router
+/// registers no `/tenants/{tenant}/…` routes, unlike the built-in REST
+/// dispatcher. Such a request must 404 — failing closed — rather than being
+/// silently served from the default tenant partition.
+#[tokio::test]
+async fn axum_tenant_prefixed_paths_are_not_routed() {
+    let base = start_test_server_full().await;
+    let task_id = create_task(&base).await;
+
+    let (status, _) = http_request("GET", &format!("{base}/tenants/acme/tasks/{task_id}")).await;
+    assert_eq!(
+        status, 404,
+        "a tenant-prefixed path must not resolve on this router"
+    );
+
+    // And the un-prefixed form still works, so the assertion above is about
+    // the prefix rather than a broken server.
+    let (status, _) = http_request("GET", &format!("{base}/tasks/{task_id}")).await;
+    assert_eq!(status, 200);
+}

--- a/crates/a2a-protocol-types/src/signing.rs
+++ b/crates/a2a-protocol-types/src/signing.rs
@@ -290,20 +290,121 @@ pub fn sign_agent_card(
     })
 }
 
+// ── JWS protected header ────────────────────────────────────────────────────
+
+/// The decoded JWS protected header of an [`AgentCardSignature`].
+///
+/// Spec §8.4.3 step 2 requires a verifying client to "retrieve the public key
+/// using the `kid` and `jku` (or from a trusted key store)". That step is the
+/// caller's — see [`verify_agent_card`] for why — but the caller cannot
+/// perform it without reading those two fields, and they live base64url-encoded
+/// inside [`AgentCardSignature::protected`]. [`signature_header`] decodes them
+/// so callers do not have to hand-roll base64 and JSON parsing to obey a MUST.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SignatureHeader {
+    /// The JWS algorithm (`alg`). Only `ES256` is verifiable by this module.
+    pub alg: String,
+    /// The key identifier (`kid`), when the signer supplied one.
+    pub kid: Option<String>,
+    /// The JWK Set URL (`jku`) to retrieve the signing key from, when present.
+    ///
+    /// Spec §8.4.3 says public keys **SHOULD** be retrieved over secure
+    /// channels; treat a non-HTTPS `jku`, or one pointing outside the agent's
+    /// own origin, as untrusted.
+    pub jku: Option<String>,
+}
+
+/// Decodes the JWS protected header of an [`AgentCardSignature`].
+///
+/// This performs **no** cryptographic verification — the header is attacker-
+/// controlled until [`verify_agent_card`] succeeds against a key the caller
+/// trusts. Use it to decide *which* key to retrieve, never to decide whether
+/// to trust the card.
+///
+/// # Errors
+///
+/// Returns an error if `protected` is not valid base64url, is not valid JSON,
+/// or carries no `alg`.
+pub fn signature_header(sig: &AgentCardSignature) -> A2aResult<SignatureHeader> {
+    let header_bytes = URL_SAFE_NO_PAD
+        .decode(&sig.protected)
+        .map_err(|e| A2aError::internal(format!("invalid header encoding: {e}")))?;
+    let header: serde_json::Value = serde_json::from_slice(&header_bytes)
+        .map_err(|e| A2aError::internal(format!("invalid header JSON: {e}")))?;
+    let str_field = |k: &str| {
+        header
+            .get(k)
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned)
+    };
+    Ok(SignatureHeader {
+        alg: str_field("alg").ok_or_else(|| A2aError::internal("missing alg in header"))?,
+        kid: str_field("kid"),
+        jku: str_field("jku"),
+    })
+}
+
 // ── JWS Verification ────────────────────────────────────────────────────────
 
 /// Verifies an [`AgentCardSignature`] against an [`AgentCard`] using the
 /// given public key.
 ///
+/// # Scope: this performs spec §8.4.3 steps 3–6, not 1–2
+///
+/// Spec §8.4.3 lists six steps a verifying client **MUST** perform. This
+/// function performs the last four — exclude `signatures`, drop defaults,
+/// canonicalize per RFC 8785, verify — against **a key the caller has already
+/// chosen**. Steps 1 and 2, extracting the signature and *retrieving the
+/// public key* "using the `kid` and `jku` (or from a trusted key store)",
+/// are the caller's, because this crate takes the key as a parameter.
+///
+/// ## Key expiry and revocation is therefore the caller's obligation
+///
+/// The same section states that **"expired or revoked keys MUST NOT be used
+/// for verification"** (the TCK tracks this as `CARD-SIGN-004`, which it tags
+/// `not-automatable`). That obligation attaches to key *retrieval* — step 2 —
+/// and this function is reached only after a key has been retrieved. Passing a
+/// revoked key here will verify successfully, because the mathematics is
+/// sound; the key was simply one the caller was not entitled to trust.
+///
+/// This split is deliberate, not an omission, and the reason is that expiry
+/// and revocation are not properties this crate can observe:
+///
+/// * A JWKS key is revoked by *removal from the `jku` endpoint*. Detecting
+///   that means re-fetching over HTTPS. `a2a-protocol-types` has no network
+///   dependency and should not acquire one — it is the shared wire-type crate
+///   that every other crate, including `no-network` consumers, depends on.
+/// * An X.509 key expires per `notAfter` and is revoked per CRL/OCSP. Checking
+///   that means an `x5c` chain, a trust store, and a revocation fetcher —
+///   duplicating `webpki`/`rustls` inside a serialization crate.
+///
+/// Both belong to the layer that already owns transport and trust policy.
+///
+/// ## What a caller must do
+///
+/// 1. Read [`signature_header`] to obtain `kid` and `jku`.
+/// 2. Retrieve the key from a trusted key store, or over HTTPS from a `jku`
+///    the caller independently trusts — never one taken on the card's word
+///    alone, since the header is unauthenticated until this call returns `Ok`.
+/// 3. Apply lifecycle policy: reject keys absent from the current JWKS, past
+///    `notAfter`, or listed as revoked.
+/// 4. Only then call this function.
+///
+/// Multiple signatures **MAY** be present to support key rotation, so a caller
+/// should try each until one verifies under a currently-valid key.
+///
 /// # Arguments
 ///
 /// * `card` — The agent card that was signed.
 /// * `sig` — The signature to verify.
-/// * `public_key_der` — DER-encoded public key (`SubjectPublicKeyInfo`).
+/// * `public_key_der` — DER-encoded public key (`SubjectPublicKeyInfo`),
+///   already established by the caller to be currently valid.
 ///
 /// # Errors
 ///
-/// Returns an error if canonicalization fails or the signature is invalid.
+/// Returns an error if canonicalization fails, the protected header is
+/// malformed, the algorithm is not `ES256`, or the signature is invalid.
 pub fn verify_agent_card(
     card: &AgentCard,
     sig: &AgentCardSignature,
@@ -321,16 +422,7 @@ pub fn verify_agent_card(
         .map_err(|e| A2aError::internal(format!("invalid signature encoding: {e}")))?;
 
     // Determine algorithm from the protected header.
-    let header_bytes = URL_SAFE_NO_PAD
-        .decode(&sig.protected)
-        .map_err(|e| A2aError::internal(format!("invalid header encoding: {e}")))?;
-    let header: serde_json::Value = serde_json::from_slice(&header_bytes)
-        .map_err(|e| A2aError::internal(format!("invalid header JSON: {e}")))?;
-    let alg = header
-        .get("alg")
-        .and_then(serde_json::Value::as_str)
-        .ok_or_else(|| A2aError::internal("missing alg in header"))?;
-
+    let alg = signature_header(sig)?.alg;
     if alg != "ES256" {
         return Err(A2aError::internal(format!("unsupported algorithm: {alg}")));
     }
@@ -574,6 +666,106 @@ mod tests {
         let header: serde_json::Value = serde_json::from_slice(&header_bytes).unwrap();
         assert_eq!(header["alg"], "ES256");
         assert_eq!(header["kid"], "my-key-id");
+    }
+
+    // ── signature_header: spec §8.4.3 step 2 support ─────────────────────
+
+    #[test]
+    fn signature_header_exposes_alg_and_kid() {
+        let card = minimal_card();
+        let rng = SystemRandom::new();
+        let pkcs8 = EcdsaKeyPair::generate_pkcs8(&signature::ECDSA_P256_SHA256_FIXED_SIGNING, &rng)
+            .unwrap();
+        let sig = sign_agent_card(&card, pkcs8.as_ref(), Some("my-key-id")).unwrap();
+
+        let header = signature_header(&sig).unwrap();
+        assert_eq!(header.alg, "ES256");
+        assert_eq!(header.kid.as_deref(), Some("my-key-id"));
+        // This SDK's signer does not emit `jku`; a card verified via `jku`
+        // must have been signed by something that does.
+        assert_eq!(header.jku, None);
+    }
+
+    #[test]
+    fn signature_header_kid_is_none_when_unsigned_with_one() {
+        let card = minimal_card();
+        let rng = SystemRandom::new();
+        let pkcs8 = EcdsaKeyPair::generate_pkcs8(&signature::ECDSA_P256_SHA256_FIXED_SIGNING, &rng)
+            .unwrap();
+        let sig = sign_agent_card(&card, pkcs8.as_ref(), None).unwrap();
+
+        let header = signature_header(&sig).unwrap();
+        assert_eq!(header.alg, "ES256");
+        assert_eq!(header.kid, None);
+    }
+
+    #[test]
+    fn signature_header_reads_jku_from_a_foreign_signer() {
+        // The spec's own §8.4.2 example header. Constructed by hand rather
+        // than via sign_agent_card, because this SDK does not emit `jku` —
+        // the point is that a *verifier* can read one written by anything.
+        let header = serde_json::json!({
+            "alg": "ES256",
+            "typ": "JOSE",
+            "kid": "key-1",
+            "jku": "https://example.com/agent/jwks.json",
+        });
+        let sig = AgentCardSignature {
+            protected: URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).unwrap()),
+            signature: String::new(),
+            header: None,
+        };
+
+        let parsed = signature_header(&sig).unwrap();
+        assert_eq!(parsed.alg, "ES256");
+        assert_eq!(parsed.kid.as_deref(), Some("key-1"));
+        assert_eq!(
+            parsed.jku.as_deref(),
+            Some("https://example.com/agent/jwks.json")
+        );
+    }
+
+    #[test]
+    fn signature_header_rejects_malformed_input() {
+        let bad_b64 = AgentCardSignature {
+            protected: "!!!not base64!!!".into(),
+            signature: String::new(),
+            header: None,
+        };
+        assert!(signature_header(&bad_b64).is_err());
+
+        let not_json = AgentCardSignature {
+            protected: URL_SAFE_NO_PAD.encode(b"this is not json"),
+            signature: String::new(),
+            header: None,
+        };
+        assert!(signature_header(&not_json).is_err());
+
+        // Valid JSON, but no `alg` — nothing can be verified without it.
+        let no_alg = AgentCardSignature {
+            protected: URL_SAFE_NO_PAD.encode(br#"{"kid":"k"}"#),
+            signature: String::new(),
+            header: None,
+        };
+        assert!(signature_header(&no_alg).is_err());
+    }
+
+    #[test]
+    fn verify_rejects_non_es256_algorithm() {
+        // Guards the alg check that now reads through signature_header:
+        // a header claiming RS256 must be refused, not silently verified
+        // with the ES256 verifier.
+        let card = minimal_card();
+        let sig = AgentCardSignature {
+            protected: URL_SAFE_NO_PAD.encode(br#"{"alg":"RS256"}"#),
+            signature: URL_SAFE_NO_PAD.encode([0_u8; 64]),
+            header: None,
+        };
+        let err = verify_agent_card(&card, &sig, &[0_u8; 65]).unwrap_err();
+        assert!(
+            format!("{err}").contains("unsupported algorithm"),
+            "expected an unsupported-algorithm error, got: {err}"
+        );
     }
 
     // ── Canonicalization boundary tests ──────────────────────────────────

--- a/deny.toml
+++ b/deny.toml
@@ -46,21 +46,94 @@ ignore    = []
 # Banned crates
 # ---------------------------------------------------------------------------
 [bans]
-# NOT tightened to "deny" (2026-07-30 pass): `cargo deny check bans` on the
-# full, untruncated output shows 25 distinct crates with duplicate versions
-# in the graph today (windows-sys and its per-target siblings, rand/rand_core/
-# rand_chacha, thiserror/thiserror-impl, toml_edit/toml_datetime/winnow,
-# proc-macro-crate, heck, strsim, itertools, hashbrown, getrandom, r-efi,
-# core-foundation, convert_case) — an initial pass here mistakenly treated
-# `winnow` as the only one, going only off a `tail`-truncated check, and
-# would have shipped `deny` with 24 other violations still live had it not
-# been re-verified against the full log. Closing this properly means an
-# audit of all 25 (most are ordinary transitive-dependency-tree splits from
-# `rig-core`/`genai`/Windows-target crates, not obviously fixable from this
-# repo alone) — real, worthwhile work, but out of scope for this pass. Left
-# at "warn" rather than guessing at 25 skip entries.
-multiple-versions = "warn"
+# Tightened to "deny" after a per-crate audit (2026-07-31). Read the skip
+# list below before adding to it.
+#
+# History worth keeping: an early pass here treated `winnow` as the only
+# duplicate, going off a `tail`-truncated check, and would have shipped
+# "deny" with 24 live violations. The full, untruncated output is the only
+# valid input to this decision. Re-measured 2026-07-31 on the complete
+# 2,129-line log: **26** distinct crates, not the 25 recorded in the previous
+# pass — that count was one low.
+#
+# What the audit found, and why "deny" is now safe:
+#
+#   * Scoped to the four *published* crates at default features — i.e. what a
+#     consumer of this SDK actually resolves — there are only **2** duplicated
+#     crates, `getrandom` and `windows-sys`. Both trace to `ring 0.17.14`'s own
+#     pinned dependencies (via `rustls`), which this repo cannot influence.
+#   * The remaining 24 enter through workspace-only members: the `examples/*`
+#     agents (`rig-core`, `genai` and their trees), `benches`, `tck/sut`, and
+#     optional `sqlx` backends. They are not in any published dependency graph.
+#
+# So the duplicates are ecosystem version-skew in other people's trees, not
+# something this repo can resolve by upgrading. "warn" was the honest setting
+# while that was unverified; it is also a setting nobody reads. "deny" plus a
+# reviewed skip list is strictly stronger: every crate below has been looked
+# at, and any *new* duplicate — including one introduced by our own change —
+# is now an error rather than a line in a log.
+#
+# Skips are bare crate names, deliberately, not pinned versions. A pinned skip
+# turns a routine `cargo update` into a red CI run for a non-issue; a bare name
+# says "duplicates of this crate are known and accepted", while still catching
+# any crate not on the list. cargo-deny flags unused skip entries, so an entry
+# that stops being needed surfaces rather than rotting.
+multiple-versions = "deny"
 wildcards         = "warn"
+
+skip = [
+    # --- Reachable from the published crates (2) ---
+    # Both pinned by `ring 0.17.14` (via rustls/hyper-rustls/tokio-rustls)
+    # against newer versions elsewhere in the graph. Not fixable here; it
+    # resolves when `ring` bumps its own floor.
+    { crate = "getrandom", reason = "ring 0.17 pins 0.2.x; rand 0.9 lineage uses 0.3/0.4" },
+    { crate = "windows-sys", reason = "ring 0.17 pins 0.52; newer crates use 0.61" },
+
+    # --- Windows per-target crates (8) ---
+    # One `windows-targets` split fans out into eight identical
+    # per-architecture duplicates. They are a single upstream fact reported
+    # eight times, and none is compiled on this project's CI targets.
+    { crate = "windows-targets", reason = "0.42/0.48 vs 0.52 split from transitive Windows deps" },
+    { crate = "windows_aarch64_gnullvm", reason = "fanout of the windows-targets split" },
+    { crate = "windows_aarch64_msvc", reason = "fanout of the windows-targets split" },
+    { crate = "windows_i686_gnu", reason = "fanout of the windows-targets split" },
+    { crate = "windows_i686_msvc", reason = "fanout of the windows-targets split" },
+    { crate = "windows_x86_64_gnu", reason = "fanout of the windows-targets split" },
+    { crate = "windows_x86_64_gnullvm", reason = "fanout of the windows-targets split" },
+    { crate = "windows_x86_64_msvc", reason = "fanout of the windows-targets split" },
+
+    # --- The rand 0.8 -> 0.9 ecosystem migration (4) ---
+    # `sqlx-postgres` and `nanoid` (via rig-core) still sit on the 0.8
+    # lineage while newer crates are on 0.9. Closes when they migrate.
+    { crate = "rand", reason = "sqlx-postgres/nanoid on 0.8; newer deps on 0.9" },
+    { crate = "rand_chacha", reason = "fanout of the rand 0.8 -> 0.9 migration" },
+    { crate = "rand_core", reason = "fanout of the rand 0.8 -> 0.9 migration" },
+    { crate = "r-efi", reason = "pulled by the split getrandom versions" },
+
+    # --- thiserror 1 -> 2 migration (2) ---
+    { crate = "thiserror", reason = "transitive deps still on 1.x; workspace is on 2.x" },
+    { crate = "thiserror-impl", reason = "fanout of the thiserror 1 -> 2 migration" },
+
+    # --- TOML parsing stack, via proc-macro tooling (3) ---
+    { crate = "toml_edit", reason = "proc-macro-crate 1.x vs 3.x pull different toml_edit" },
+    { crate = "toml_datetime", reason = "fanout of the toml_edit split" },
+    { crate = "winnow", reason = "fanout of the toml_edit split" },
+    { crate = "proc-macro-crate", reason = "1.x from older derive macros, 3.x from newer" },
+
+    # --- Ordinary build-tooling version skew in transitive trees (7) ---
+    { crate = "convert_case", reason = "derive-macro helper skew in transitive deps" },
+    { crate = "core-foundation", reason = "macOS-only; 0.9 vs 0.10 skew in TLS stacks" },
+    { crate = "hashbrown", reason = "indexmap generations pull 0.15 and 0.17" },
+    { crate = "heck", reason = "0.4 from older derive macros, 0.5 from newer" },
+    { crate = "itertools", reason = "0.13 vs 0.14 skew across transitive crates" },
+    { crate = "strsim", reason = "clap/derive tooling skew" },
+]
+# Deliberately NOT skipped: `redox_syscall` duplicates only in the
+# `--all-features` graph, and `[graph] all-features = false` above means this
+# check does not resolve that graph. cargo-deny reported the entry as
+# `unmatched-skip`, so it was removed rather than left as decoration — an
+# exemption for something that is not happening is how a skip list starts
+# rotting into a blanket waiver.
 
 deny = [
     # reqwest carries 30+ transitive deps we do not need.

--- a/docs/official-tck-findings.md
+++ b/docs/official-tck-findings.md
@@ -116,20 +116,20 @@ per-item evidence is in §15–§17.
 |---|---:|---|
 | `PASS`, `full` profile | 88 | — already passing |
 | `PASS`, `minimal` profile only (`CORE-CAP-001/002/003`) | 3 | — already passing (§15) |
-| **Measured passing, both profiles** | **91** | |
-| `CORE-CAP-004` | 1 | **No** — blocked on upstream `a2a-tck` [#193](https://github.com/a2aproject/a2a-tck/issues/193) (§12) |
+| `PASS`, `extension` profile only (`CORE-CAP-004`) | 1 | — already passing (§18) |
+| **Measured passing, all three profiles** | **92** | |
 | `CARD-EXT-002` | 1 | **No** — structurally inapplicable; this SDK cannot declare `extendedAgentCard` and simultaneously have none (§12) |
 | `NOT TESTED` | 21 | **No** — zero test functions exist upstream; 5 carry the suite's own `not-automatable` tag and a 6th (`GRPC-SVC-003`) the same verdict as an inline comment, 2 are an explicit upstream "Won't Do", 13 are open upstream backlog items (§16) |
 | **Total** | **114** | |
 
-So: **91 of 114 MUST requirements are measurably passing, 0 are failing, and
-all 23 of the remainder are upstream-blocked or structurally inapplicable —
+So: **92 of 114 MUST requirements are measurably passing, 0 are failing, and
+all 22 of the remainder are upstream-untested or structurally inapplicable —
 none is a defect in this SDK.** The reported "100.0% MUST compatibility" is
 100% *of the requirements the suite is able to grade*, and that is the
 strongest true statement available. A number like "114/114" is not
 achievable by any implementation against `a2a-tck` as it exists today,
 including the reference implementations — and any project claiming it should
-be asked which of the 23 it closed and how.
+be asked which of the 22 it closed and how.
 
 The same holds per level: `SHOULD` is 7 `PASS` / 0 `FAIL` / 4 `NOT TESTED`
 (all four in the same upstream `AUTH-*` backlog item, `task-27`), and `MAY`
@@ -986,20 +986,11 @@ requirement result, and the gate returns 0 on the minimal-profile report.
 
 ### Still open
 
-- `CORE-CAP-004`: skipped under both profiles. Root cause identified in
-  §15 — the SUT's card never declares the sentinel extension the test
-  requires, on either profile — and **now known to be blocked upstream, not
-  merely undone here**: `a2aproject/a2a-tck` issue
-  [#193](https://github.com/a2aproject/a2a-tck/issues/193) (open) reports
-  that the suite does not send `A2A-Extensions` activation on ordinary
-  positive requests, so "servers that correctly advertise and enforce
-  required extensions cannot pass the TCK." Declaring the sentinel extension
-  would therefore fail unrelated `CORE-SEND-*`/`CORE-STREAM-*` checks — the
-  exact regression §15 predicted from reading `builder.rs`, independently
-  confirmed by upstream's own bug report. That issue also notes other SDKs
-  have used "CI-side monkey patches or `sitecustomize.py` shims" to pass this
-  requirement; that is precisely the class of workaround this project does
-  not ship. Blocked pending #193.
+- ~~`CORE-CAP-004`~~ — **closed, see §18.** It is now graded `PASS` on both
+  `jsonrpc` and `http_json` by a third SUT profile. The upstream constraint
+  (#193) is real and still open, but it bounds *how* the requirement can be
+  measured, not *whether* it can be: a scoped run measures it without any
+  change to the harness.
 - `CARD-EXT-002`: needs a server that *declares* `extendedAgentCard` while
   having no extended card configured. This SDK cannot enter that state — the
   handler derives the extended card from the configured agent card (verified
@@ -1294,6 +1285,9 @@ highest-value, most tractable gap to close: it is not tractable via the
 official TCK at all, and only 3 of its 4 sub-requirements are actually
 covered by this SDK's own tests.
 
+**That "may be a reasonable layering choice" is now a decision rather than an
+open question — see §19.**
+
 **Group 2 — ruled out of scope by the suite's own backlog (2 requirements:
 `VER-CLIENT-001`, `VER-CLIENT-002`).** `backlog/archive/tasks/task-30` (this
 project's own `a2a-tck` checkout, `main` at `5996b79`) carries the
@@ -1441,3 +1435,188 @@ with the standalone reproduction at
 includes a fix that was applied to a local upstream checkout and verified:
 with it, the previously-erroring test skips cleanly and the server's real
 error text reaches the skip message. Submitting it remains a human decision.
+
+## 18. `CORE-CAP-004` is closed: a scoped third profile, not a harness patch
+
+*Fixed. Verified by run.*
+
+This requirement sat as the last `SKIPPED` MUST that was neither structurally
+inapplicable nor untested upstream. §12 recorded it as "blocked pending
+[#193](https://github.com/a2aproject/a2a-tck/issues/193)". That framing was
+too strong, and this section corrects it: **#193 constrains how the
+requirement can be measured, not whether it can be.**
+
+### What the test actually needs
+
+`TestCapabilityExtensionRequired` (in
+`tests/compatibility/core_operations/test_error_handling.py`) skips unless the
+agent card declares `urn:a2a:tck:required-extension` with `required: true`. Given
+that card, it sends an ordinary `SendMessage` carrying no `A2A-Extensions`
+header and requires `ExtensionSupportRequiredError` back, on `jsonrpc` and
+`http_json`. There is no gRPC variant upstream.
+
+Neither existing profile declares any extension, so under both the `full` and
+`minimal` cards the requirement records `SKIPPED` and is never graded.
+
+### Why an unscoped run cannot work, measured rather than assumed
+
+Required-extension enforcement is per-request (spec §3.3.4), and this SDK
+implements it that way — `ensure_required_extensions` is called from
+`messaging.rs`, `get_task.rs`, `list_tasks.rs`, `cancel_task.rs`,
+`subscribe.rs` and `push_config.rs`. The suite does not send `A2A-Extensions`
+activation on its ordinary positive requests, which is exactly what #193
+reports.
+
+That prediction was tested, not taken on faith. Running the **whole** suite
+against a card declaring the required extension produces:
+
+```
+72 failed, 56 passed, 129 skipped, 8 xfailed
+```
+
+— every `CORE-SEND-*`, `CORE-MULTI-*`, error-code and status-code check
+answered with `ExtensionSupportRequiredError`. Notably `CORE-CAP-004` itself
+reports `PASS` even in that run, which is what made clear the SDK behaviour
+was never the problem.
+
+### The fix: a third profile, scoped
+
+`SUT_PROFILE=extension` serves the `full` capability set plus the sentinel
+extension marked `required: true`, and the suite is run with
+`-k TestCapabilityExtensionRequired`. Result:
+
+```
+2 passed, 263 deselected
+CORE-CAP-004  {jsonrpc: PASS, http_json: PASS}
+```
+
+Verified end to end before wiring into CI, at the SDK's own edge:
+
+| Request | Response |
+|---|---|
+| `SendMessage`, no `A2A-Extensions` | `-32008` `EXTENSION_SUPPORT_REQUIRED`, naming the missing URI |
+| `SendMessage`, `A2A-Extensions: urn:a2a:tck:required-extension` | normal task result |
+
+**This is scoping, not a waiver.** Every requirement excluded from this run is
+graded by the full-profile run, which is the one the baseline gate reads.
+Nothing is exempted from measurement; it is measured elsewhere. The
+distinction matters because upstream notes other SDKs pass this requirement
+with a `sitecustomize.py` shim that monkey-patches the harness into sending
+the header — that changes the suite rather than the SUT, and is not used here.
+
+### The silent-green hole this opened, and how it is closed
+
+A scoped run that selects **zero** tests reports zero failures, and the
+differential gate accepts zero failures as success. So if upstream renamed the
+test class, the `-k` filter would match nothing and the job would go green
+having measured nothing — the precise failure mode
+`tck/scripts/check_conformance.py` exists to prevent.
+
+`--require-pass REQ_ID` closes it: the gate now fails unless the named
+requirement is graded `PASS`, treating absent, `SKIPPED` and `NOT TESTED`
+alike as unmet. Verified in both directions — exit 0 against the scoped
+extension report, exit 1 against the full-profile report where `CORE-CAP-004`
+is `SKIPPED`.
+
+### Also fixed here: the report-overwrite trap, in CI
+
+Every profile run writes the same `reports/compatibility.json`. The workflow
+ran full → minimal → extension, so the uploaded artifact's
+`compatibility.json` was whichever profile ran last, presented as if it were
+the gate-bearing full-profile report. The full run now copies its report to
+`/tmp/full-compatibility.json` immediately, the gate reads that copy, and all
+three per-profile reports are uploaded under distinct names.
+
+### Corrected while doing this
+
+`tck/sut/src/main.rs`'s `Profile` doc comment claimed the minimal profile
+makes `CORE-CAP-001/002/004` observable. Two errors in one line: `CORE-CAP-004`
+is `SKIPPED` under the minimal profile (that is this whole section), and
+`CORE-CAP-003` — which the minimal profile genuinely does make observable — was
+omitted. Checked against both runs' `compatibility.json`: the requirements the
+minimal profile adds are exactly `CORE-CAP-001`, `CORE-CAP-002` and
+`CORE-CAP-003`.
+
+## 19. `CARD-SIGN-004` decided: key lifecycle is the caller's, and the API now says so
+
+*Decided and implemented. §16 left this as "may be a reasonable layering
+choice"; leaving it unstated was the actual defect.*
+
+### What the spec requires, quoted rather than paraphrased
+
+Spec §8.4.3 opens by naming who is bound: **"Clients verifying Agent Card
+signatures MUST:"**, then lists six steps. Step 2 is *"Retrieve the public key
+using the `kid` and `jku` (or from a trusted key store)"*. Among the security
+considerations that follow is the `CARD-SIGN-004` sentence: *"Expired or
+revoked keys **MUST NOT** be used for verification."*
+
+Read in place, the obligation attaches to **step 2 — key retrieval** — not to
+the signature check. There is no third state: a key is either one the verifier
+was entitled to use or it is not, and that is settled before any curve
+arithmetic happens.
+
+### The decision
+
+`verify_agent_card` implements **steps 3–6** and takes the public key as a
+parameter. Steps 1–2, including lifecycle policy, belong to the caller.
+Recorded here rather than merely believed, because the alternative was
+considered and rejected on concrete grounds:
+
+* A JWKS key is revoked by *removal from the `jku` endpoint*. Detecting that
+  requires re-fetching over HTTPS. `a2a-protocol-types` has **no network
+  dependency** — verified this session, its entire dependency list is `serde`,
+  `serde_json`, `base64`, `ring`, `prost`, `prost-types`, `time` — and it is
+  the shared wire-type crate everything else depends on. An HTTP client does
+  not belong in it.
+* An X.509 key expires per `notAfter` and is revoked per CRL/OCSP. Supporting
+  that means an `x5c` chain, a trust store and a revocation fetcher, i.e.
+  reimplementing `webpki`/`rustls` inside a serialization crate.
+
+Both belong to the layer that already owns transport and trust policy. Note
+that this SDK *does* already do JWKS-with-`kid` resolution — in
+`a2a-protocol-server`'s `auth/jwt.rs`, for inbound request authentication.
+That is the correct layer for it; agent-card key retrieval would sit there
+too, not in the types crate.
+
+### Why documenting alone would have been a dodge, and what was done instead
+
+A caller told "retrieve the key using `kid` and `jku`" **could not do it**:
+those fields live base64url-encoded inside `AgentCardSignature.protected`, and
+nothing in the public API decoded them. `sign_agent_card` could *write* a
+`kid`; nothing could *read* one back. So the obligation was assigned to a
+caller who had no supported means of discharging it — the documentation would
+have been true and useless.
+
+Added: `signing::signature_header(&AgentCardSignature) -> A2aResult<SignatureHeader>`,
+exposing `alg`, `kid` and `jku`. Additive, no new dependencies, and it makes
+step 2 performable. `verify_agent_card` now reads its own `alg` through it,
+so there is one header-parsing path rather than two.
+
+The doc comment on `verify_agent_card` states the split, quotes the MUST NOT,
+gives the four-step caller recipe, and warns that the header is attacker-
+controlled until verification succeeds — so `jku` must never be trusted on the
+card's own word.
+
+### Known limitation, stated rather than left to be discovered
+
+`sign_agent_card` does **not** emit `jku`; it writes only `alg` and an optional
+`kid`. Cards signed by this SDK are therefore verifiable via a trusted key
+store — which §8.4.3 explicitly permits ("or from a trusted key store") — but
+they do not advertise where their JWKS lives. This is a spec-permitted subset,
+not a violation, and it is not fixed here because changing `sign_agent_card`'s
+signature is a breaking API change that belongs in a deliberate release.
+`signature_header` reads `jku` from cards signed by anything else, so
+verification interop is unaffected.
+
+### Coverage
+
+Five tests added to `signing.rs`: `alg`/`kid` round-trip, absent `kid`, `jku`
+read back from the spec's own §8.4.2 example header, malformed input rejected
+in three shapes (bad base64, non-JSON, missing `alg`), and a non-ES256 `alg`
+refused rather than silently verified. `cargo test -p a2a-protocol-types
+--features signing --lib signing`: 22 passed, 0 failed.
+
+This does **not** make `CARD-SIGN-004` gradeable by the TCK — it carries the
+suite's `not-automatable` tag and has no test function upstream, so it remains
+in the 21 `NOT TESTED`. It removes the gap in *this SDK*, which is the part
+that was ours to close.

--- a/tck/scripts/check_conformance.py
+++ b/tck/scripts/check_conformance.py
@@ -28,10 +28,18 @@ Transport granularity matters too: PUSH-CREATE-001 fails on jsonrpc and passes
 on http_json today. A requirement-level baseline would not notice it starting
 to fail on http_json as well.
 
+A differential gate alone is not enough for a *scoped* run — one restricted to
+a subset of the suite with `-k`. There, "no failures" is also what an empty
+test selection produces, so an upstream rename that makes the filter match
+nothing would read as success. `--require-pass` closes that: it asserts a named
+requirement was actually measured and graded PASS, so a run that measured
+nothing fails loudly instead of passing quietly.
+
 Usage:
     check_conformance.py --report reports/compatibility.json \\
                          --baseline tck/conformance-baseline.json
     check_conformance.py --report … --baseline … --update   # rewrite baseline
+    check_conformance.py --report … --baseline … --require-pass CORE-CAP-004
 """
 
 from __future__ import annotations
@@ -103,6 +111,34 @@ def flatten(failures: dict[str, dict[str, str]]) -> set[tuple[str, str]]:
     return {(req, tr) for req, trs in failures.items() for tr in trs}
 
 
+def unmet_requirements(report: dict, required: list[str]) -> list[str]:
+    """Return a message per requirement in `required` that is not graded PASS.
+
+    Absent, SKIPPED and NOT TESTED all count as unmet. That is the point: on a
+    scoped run those are exactly what "the filter selected nothing" looks like,
+    and they are indistinguishable from success to the differential gate.
+    """
+    per_req = report.get("per_requirement")
+    if not isinstance(per_req, dict):
+        sys.exit("error: report has no 'per_requirement' object — wrong file?")
+
+    problems: list[str] = []
+    for req_id in required:
+        entry = per_req.get(req_id)
+        if not isinstance(entry, dict):
+            problems.append(f"  {req_id} -> absent from the report entirely")
+            continue
+        status = entry.get("status")
+        if status != "PASS":
+            transports = entry.get("transports") or {}
+            detail = (
+                ", ".join(f"{t}={s}" for t, s in sorted(transports.items()))
+                or "no transport results"
+            )
+            problems.append(f"  {req_id} -> {status} ({detail})")
+    return problems
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--report", required=True, type=Path)
@@ -111,6 +147,17 @@ def main() -> int:
         "--update",
         action="store_true",
         help="Rewrite the baseline from this report instead of checking it.",
+    )
+    ap.add_argument(
+        "--require-pass",
+        action="append",
+        default=[],
+        metavar="REQ_ID",
+        help=(
+            "Fail unless this requirement is graded PASS in the report. "
+            "Repeatable. Use on scoped runs, where an empty test selection "
+            "would otherwise look identical to a clean one."
+        ),
     )
     args = ap.parse_args()
 
@@ -147,11 +194,15 @@ def main() -> int:
     regressions = sorted(obs - base)
     fixed = sorted(base - obs)
 
+    unmet = unmet_requirements(report, args.require_pass)
+
     summary = report.get("summary", {})
     print("Official a2a-tck — differential conformance gate")
     print(f"  MUST compatibility : {summary.get('must_compatibility', '?')}")
     print(f"  known failing pairs: {len(base)}")
     print(f"  observed failing   : {len(obs)}")
+    if args.require_pass:
+        print(f"  required to PASS   : {', '.join(args.require_pass)}")
 
     if regressions:
         print(f"\nREGRESSION — {len(regressions)} failing check(s) not in the baseline:")
@@ -169,7 +220,15 @@ def main() -> int:
         print("gating. Run:")
         print("  tck/scripts/check_conformance.py --report … --baseline … --update")
 
-    if regressions or fixed:
+    if unmet:
+        print(f"\nNOT MEASURED — {len(unmet)} requirement(s) required to PASS did not:")
+        for line in unmet:
+            print(line)
+        print("\nOn a scoped run this usually means the test selection matched")
+        print("nothing — e.g. upstream renamed the test the -k filter names.")
+        print("The suite reporting no failures is not evidence it ran.")
+
+    if regressions or fixed or unmet:
         return 1
 
     print("\nOK — failures exactly match the baseline; no regressions.")

--- a/tck/sut/src/main.rs
+++ b/tck/sut/src/main.rs
@@ -264,10 +264,22 @@ impl AgentExecutor for TckSutExecutor {
 /// Which capability set the SUT advertises.
 ///
 /// Several MUST requirements are only *reachable* when the agent advertises
-/// **less**: `CORE-CAP-001/002/004` check that a server rejects push and
-/// streaming operations it never claimed to support, and the TCK skips them
-/// against an agent that does claim them. One SUT cannot exercise both sides,
-/// so the profile is selectable and CI runs the suite once per profile.
+/// something other than the full capability set, and one SUT cannot exercise
+/// every side at once — so the profile is selectable and CI runs the suite
+/// once per profile:
+///
+/// * [`Profile::Minimal`] advertises **less**. `CORE-CAP-001/002/003` check
+///   that a server rejects streaming, push and extended-card operations it
+///   never claimed to support, and the TCK skips them against an agent that
+///   does claim them.
+/// * [`Profile::Extension`] advertises a **required extension**, which is the
+///   only way `CORE-CAP-004` becomes observable at all.
+///
+/// Verified against `reports/compatibility.json` from both runs: the three
+/// requirements the minimal profile adds are exactly `CORE-CAP-001`,
+/// `CORE-CAP-002` and `CORE-CAP-003`. `CORE-CAP-004` is `SKIPPED` under both
+/// Full and Minimal, because neither card declares the sentinel extension its
+/// test requires.
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Profile {
     /// Everything on — the profile the conformance gate runs against.
@@ -275,16 +287,49 @@ enum Profile {
     /// Streaming, push and extended card all absent, so the capability
     /// *rejection* paths become observable.
     Minimal,
+    /// Full capabilities plus [`REQUIRED_EXTENSION_URI`] declared
+    /// `required: true`, so `CORE-CAP-004`'s precondition is met.
+    ///
+    /// This profile is only usable for a **scoped** run — see that constant's
+    /// documentation for why.
+    Extension,
 }
 
 impl Profile {
     fn from_env() -> Self {
         match std::env::var("SUT_PROFILE").as_deref() {
             Ok("minimal") => Self::Minimal,
+            Ok("extension") => Self::Extension,
             _ => Self::Full,
         }
     }
 }
+
+/// The sentinel extension URI `CORE-CAP-004` looks for on the agent card.
+///
+/// The test only runs when the card declares this URI with `required: true`;
+/// otherwise it records `SKIPPED`. It then sends an ordinary `SendMessage`
+/// *without* an `A2A-Extensions` declaration and requires
+/// `ExtensionSupportRequiredError` back.
+///
+/// # Why this profile must be run scoped to `CORE-CAP-004`
+///
+/// Spec §3.3.4 says required-extension enforcement applies to every request,
+/// and this SDK implements it that way (`ensure_required_extensions` is called
+/// from `messaging.rs`, `get_task.rs`, `list_tasks.rs`, `cancel_task.rs`,
+/// `subscribe.rs` and `push_config.rs`). The TCK does not send `A2A-Extensions`
+/// activation on its ordinary positive requests — upstream
+/// [`a2aproject/a2a-tck` #193](https://github.com/a2aproject/a2a-tck/issues/193),
+/// still open — so under this profile every other `CORE-*` check would be
+/// answered with `ExtensionSupportRequiredError` and fail.
+///
+/// Those requirements are graded by the full-profile run instead. Restricting
+/// this profile to `CORE-CAP-004`'s own tests is therefore a scoping decision,
+/// not a waiver: nothing is exempted from grading, it is graded elsewhere. The
+/// alternative upstream records other SDKs taking — a `sitecustomize.py` shim
+/// that monkey-patches the harness into sending the header — is deliberately
+/// not used here, because it would change the suite rather than the SUT.
+const REQUIRED_EXTENSION_URI: &str = "urn:a2a:tck:required-extension";
 
 fn make_agent_card(base_url: &str, grpc_url: &str, profile: Profile) -> AgentCard {
     AgentCard {
@@ -336,6 +381,26 @@ fn make_agent_card(base_url: &str, grpc_url: &str, profile: Profile) -> AgentCar
             // Advertising nothing is the point: it is what lets the suite ask
             // whether unsupported operations are rejected.
             Profile::Minimal => AgentCapabilities::none(),
+            // Same capabilities as Full, plus the sentinel required extension.
+            // Keeping the rest identical to Full means the only variable this
+            // profile introduces is the extension itself.
+            Profile::Extension => {
+                let mut caps = AgentCapabilities::none()
+                    .with_streaming(true)
+                    .with_push_notifications(true)
+                    .with_extended_agent_card(true);
+                caps.extensions = Some(vec![a2a_protocol_types::extensions::AgentExtension {
+                    uri: REQUIRED_EXTENSION_URI.into(),
+                    description: Some(
+                        "TCK sentinel extension for CORE-CAP-004 (required-extension \
+                         negotiation). Carries no behaviour."
+                            .into(),
+                    ),
+                    required: Some(true),
+                    params: None,
+                }]);
+                caps
+            }
         },
         provider: None,
         icon_url: None,
@@ -424,7 +489,9 @@ async fn main() {
         &grpc_advertised,
         profile,
     ));
-    if profile == Profile::Full {
+    // Extension advertises the same capabilities as Full, so it needs the same
+    // supporting stores; only Minimal advertises nothing and needs none.
+    if profile != Profile::Minimal {
         builder = builder
             .with_push_config_store(InMemoryPushConfigStore::new())
             // The TCK runs its webhook receiver on loopback, which the


### PR DESCRIPTION
## What this changes

Six commits clearing the outstanding verification and governance debt. Three of them started as routine queue items and turned into defect reports.

**The mutation sweep has never completed, and said it had.** This began as "record the first sweep result" and found there was nothing to record. `mutants.yml` has exactly one scheduled run in its history ([30236603180](https://github.com/tomtom215/a2a-rust/actions/runs/30236603180), 2026-07-27, against `b416c1a`); two `a2a-server` shards hit the 120-minute job timeout and were cancelled — and `Mutants Summary` concluded **success** anyway. A cancelled shard still runs its upload step, so it contributes an empty `mutants.out`; the aggregator's `count()` reads zero missed mutants from it, and the job's only failure condition was `TOTAL_MISSED > 0`. Two elevenths of the workspace went unmutated under a green check.

The same hazard was already understood here for the *incremental* PR job — its header says a job that overruns "gets cancelled, so the gate silently stops enforcing" — but the full sweep had no equivalent guard. Fixed in two parts: a shard-completeness gate that fails unless the matrix result is `success` **and** the expected number of per-shard reports arrived, and `a2a-server` sharded 12 ways instead of 8 so the slowest shard finishes with headroom rather than four minutes of it. Raising the timeout instead would have been a guess — the cancelled shards' true duration is unknowable precisely because they were cancelled.

Expect the next scheduled sweep to be red if anything is genuinely incomplete. That is the point; it was silently green before.

**Two published contact addresses were undeliverable.** `a2a-rust.dev` is not registered (NXDOMAIN, verified over DNS-over-HTTPS; `github.com` and `linuxfoundation.org` resolve fine from the same host). That took out `conduct@a2a-rust.dev` — `CODE_OF_CONDUCT.md`'s *only* reporting channel, so the CoC had no working way to report anything — and `security@a2a-rust.dev`, which `SECURITY.md` listed as the **primary** vulnerability channel. A disclosure sent there would have bounced or been lost. Both now point at the maintainer address already published 62× in this repo's copyright headers (live MX verified). `SECURITY.md` promotes GitHub Security Advisories to preferred, since it stays private without a PGP key. Each file states plainly that the old address does not work, so it is not reinstated on the assumption that it does.

**Coverage defect hunt**, driven by what the coverage data showed rather than by percentage targets. Measured before and after, whole workspace 95.38% → 95.80%:

| File | Before | After |
|---|---:|---:|
| `dispatch/grpc/service.rs` | 18.2% | 81.8% |
| `dispatch/axum_adapter.rs` | 61.2% | 90.2% |
| `store/mod.rs` | 55.6% | 95.3% |
| `handler/event_processing/background/mod.rs` | 54.2% | **54.2% (untouched)** |

Two findings worth more than the percentages. `status_timestamp_sqlite` slices its formatted timestamp by byte index (`[..10]`, `[11..23]`) assuming a 4-digit year, and had no direct test — a suspected latent panic. Tested rather than reasoned about: 5- and 6-digit years, pre-epoch, year 1, leading-plus expanded years. **No panic** — a verified negative, now pinned. And `A2aRouter` registers no `/tenants/{tenant}/` routes, unlike the built-in REST dispatcher which strips that prefix and threads the tenant through. Verified it fails closed (404, not served from the default partition), documented in the module docs — which previously claimed it "handles all A2A v1.0 methods" — and pinned by a test.

Also: `deny.toml` `multiple-versions` tightened to `deny` with a reviewed skip list, and `CORE-CAP-004` closed via a third SUT profile (TCK now 92/114 MUST passing, 0 failing).

Two corrections to the premises I was given. `grpc/service.rs` is the deprecated `grpc-legacy-json` tunnel slated for removal in 0.8, not the core gRPC transport (that's `native.rs`, 83.8%) — so `ROADMAP.md` flags that removing it in 0.8 deletes the file whose coverage this PR just raised. And the postgres suite has 15 `#[ignore]`d tests, not 16; the extra grep hit was a doc-comment.

## How it was verified

Everything below was run on this branch, not inferred.

- `cargo test --workspace --all-features` — **2565 passed, 0 failed, 21 ignored**, exit 0. Re-run after the formatting fix, so it reflects the pushed tree.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — exit 0.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — exit 0.
- `cargo fmt --all -- --check` — clean. It was **not** clean on the first attempt; two hunks in `grpc_legacy_coexistence.rs` were mine, and the fixes are folded into the commits that introduced them.
- Coverage via `cargo llvm-cov --workspace --all-features`, measured before and after on the same configuration; Postgres-only store files excluded from both sides.
- The DCO job's logic was replayed locally over `origin/main..HEAD` — all six commits pass authorship and sign-off.
- The mutation findings come from the Actions API (run and per-job conclusions), not from reading the workflow and inferring what it would do.

Not verified, and deliberately so: the new mutation gate cannot be proven correct without a real sweep, which takes ~2h of CI. The next scheduled run is the test.

## Checklist

- [x] **Every commit is signed off** (`git commit -s`) by a human git author — see [DCO](../DCO) and [CONTRIBUTING](../CONTRIBUTING.md#developer-certificate-of-origin-dco)
- [x] SPDX header on every new file (one new file, `ROADMAP.md`)
- [ ] No file exceeds 500 lines — **see note below**
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes
- [x] `cargo doc --workspace --no-deps` passes without warnings
- [x] New public types/functions have doc comments
- [x] New code has tests
- [ ] `cargo mutants` shows zero surviving mutants for changed files — **not run; see note**
- [x] `CHANGELOG.md` updated if the change is user-visible
- [ ] ADR created or updated — none needed; no architectural decision was made or revised

**On the 500-line box.** CONTRIBUTING states this as a guideline for `.rs` files ("should generally stay under 500 lines… Some files exceed this guideline where splitting would harm cohesion"). Two `.rs` files cross it in this PR: `tests/axum_adapter_tests.rs` (368 → 635) and `tck/sut/src/main.rs` (458 → 525), both single cohesive units. Two more were already over and grew: `axum_adapter.rs` (721 → 746) and `signing.rs` (674 → 867). Leaving the box unticked rather than claiming a pass on a technicality.

**On the `cargo mutants` box.** Not run against the changed files. Running it here would have meant trusting the same aggregation this PR fixes, and the honest sequence is to let the corrected gate produce the first trustworthy number. `book/src/reference/mutation-history.md` records why the ledger is still empty and that the 2026-07-27 score must **not** be backfilled — it was computed from partial data.

### Authorship note

The commits were re-authored to `Tom F.` \<`tomf@tomtomtech.net`\> with matching sign-offs, following PROVENANCE.md §3.2 ("AI-assisted commits are now authored by the human who directed and reviewed the work, with the assistant credited in a trailer"). The sign-off is a DCO assertion made in your name under that documented convention — worth a look before merging. Tree content is byte-identical to the pre-rewrite commits.

### Still awaiting a decision

The prepared upstream `a2a-tck` `HTTP_JSON-SSE-001` report (`docs/upstream/a2a-tck-sse-001-report.md`) is **unfiled** — it stays that way until you say otherwise.