### PR TITLE
Stop the benchmark bot pushing to main during a release, and re-pin the manifest

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -139,6 +139,40 @@ jobs:
 
       - name: Commit benchmark results to book
         run: |
+          # Do not touch main while a release is in flight.
+          #
+          # `check_provenance_manifest.py` requires the released tree to differ
+          # from the manifest's pinned commit by nothing but the manifest. This
+          # commit adds two files to it, so a push landing between a release
+          # merge and its tag fails the release outright. That is what happened
+          # to v0.11.0 on 2026-08-30: this job pushed `chore: update benchmark
+          # results` at 20:25, and the tag cut afterwards failed immediately.
+          #
+          # It was not a race anyone lost by being slow. This workflow triggers
+          # on push to main filtered to `benches/**`, `crates/**`, `Cargo.toml`
+          # and `Cargo.lock`, and every release bumps four crate versions and
+          # both lockfiles — so *merging a release PR is itself what makes this
+          # job run*, and its push always lands in the window. Every release
+          # that touches `crates/**`, which is all of them, hit this.
+          #
+          # The signal for "in flight" is an in-tree version with no matching
+          # tag: true from the moment the release-prep merge lands until the tag
+          # is pushed, and false at every other time. Nothing is lost by
+          # skipping — results are regenerated from scratch on each run, so the
+          # first run after the tag publishes them.
+          #
+          # Fails safe: if the tag fetch fails, no tag is found and the push is
+          # skipped. Leaving main untouched is the conservative direction.
+          git fetch --tags --force --quiet origin || true
+          VERSION=$(grep -m1 '^version' crates/a2a-protocol-types/Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+          if ! git rev-parse -q --verify "refs/tags/v${VERSION}" >/dev/null; then
+            echo "::notice::in-tree version is v${VERSION} with no such tag — a release is in flight."
+            echo "Not pushing benchmark results: they would invalidate the provenance manifest"
+            echo "that the release gate checks. The first run after v${VERSION} is tagged will"
+            echo "publish them."
+            exit 0
+          fi
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add book/src/reference/benchmarks.md book/src/reference/benchmark-dashboard.html

--- a/docs/provenance-manifest.md
+++ b/docs/provenance-manifest.md
@@ -3,7 +3,7 @@
 
 # Provenance Manifest
 
-**Measured 2026-08-30 at `db795c2`. Regenerate with `scripts/provenance_manifest.sh`.**
+**Measured 2026-08-30 at `c322cec`. Regenerate with `scripts/provenance_manifest.sh`.**
 
 > Re-measured because nothing forced it to be. The figures below moved a long
 > way between `c008ab0` (2026-08-11) and this run — the share of history that
@@ -74,22 +74,22 @@ scripts/provenance_manifest.sh
 
 ## 1. What the history contains
 
-At `db795c2`, **1030 commits**, spanning **2026-03-15 to 2026-08-30**.
+At `c322cec`, **1034 commits**, spanning **2026-03-15 to 2026-08-30**.
 
 | | Commits |
 |---|---:|
-| Total reachable | 1030 |
-| Merge commits (`dco.yml` does not examine these) | 108 |
-| **Non-merge commits — the population `dco.yml` grades** | **922** |
+| Total reachable | 1034 |
+| Merge commits (`dco.yml` does not examine these) | 109 |
+| **Non-merge commits — the population `dco.yml` grades** | **925** |
 
-Git author field, all 1030 commits:
+Git author field, all 1034 commits:
 
 | Author | Commits |
 |---|---:|
 | `Claude <noreply@anthropic.com>` | 478 |
-| `Tom F. <tomf@tomtomtech.net>` | 393 |
-| `Tom F <tomtom215@users.noreply.github.com>` | 122 |
-| `github-actions[bot] <41898282+…>` | 37 |
+| `Tom F. <tomf@tomtomtech.net>` | 395 |
+| `Tom F <tomtom215@users.noreply.github.com>` | 123 |
+| `github-actions[bot] <41898282+…>` | 38 |
 
 The two `Tom F` identities are the same person: a GitHub no-reply address used
 for web-UI edits and merges, and a real address used for local commits. 106 of
@@ -97,16 +97,16 @@ the 122 no-reply commits are merge commits created by GitHub's merge button.
 
 ## 2. Verdict under the project's own DCO gate
 
-Applying `dco.yml`'s rules to all 922 non-merge commits:
+Applying `dco.yml`'s rules to all 925 non-merge commits:
 
 | Outcome | Commits | Share |
 |---|---:|---:|
-| **Would pass** — human author, matching `Signed-off-by` | **392** | 42.5% |
-| Fail — author `noreply@anthropic.com` | 477 | 51.7% |
-| Fail — author `github-actions[bot]` | 37 | 4.0% |
+| **Would pass** — human author, matching `Signed-off-by` | **394** | 42.6% |
+| Fail — author `noreply@anthropic.com` | 477 | 51.6% |
+| Fail — author `github-actions[bot]` | 38 | 4.1% |
 | Fail — human author, no matching `Signed-off-by` | 16 | 1.7% |
 
-The passing count has tripled since the 2026-08-11 measurement — 126 to 392.
+The passing count has tripled since the 2026-08-11 measurement — 126 to 394.
 The AI-authored count has not moved at all, which is the shape a closed pattern
 makes: that population is fixed and the compliant one grows past it.
 
@@ -124,14 +124,14 @@ authorship rule, which short-circuits before the sign-off check.
 
 **The pattern is closed, not ongoing.** The AI-authored commits run
 2026-03-15 to **2026-07-24** and stop there. `b416c1a` (2026-07-24, tagged
-`v0.7.0`) is where `PROVENANCE.md` §3.2 took effect. Of the **422 commits since**,
+`v0.7.0`) is where `PROVENANCE.md` §3.2 took effect. Of the **426 commits since**,
 **zero** are AI-authored:
 
-| Author, `b416c1a..db795c2` | Commits |
+| Author, `b416c1a..c322cec` | Commits |
 |---|---:|
-| `Tom F. <tomf@tomtomtech.net>` | 393 |
-| `Tom F <tomtom215@users.noreply.github.com>` | 15 |
-| `github-actions[bot]` | 14 |
+| `Tom F. <tomf@tomtomtech.net>` | 395 |
+| `Tom F <tomtom215@users.noreply.github.com>` | 16 |
+| `github-actions[bot]` | 15 |
 
 The forward policy is doing what it claims. Whatever counsel decides about the
 history, the practice that produced it has already stopped.
@@ -164,7 +164,7 @@ Every one is documentation. None is source.
 
 ### 2.2 The bot commits are ongoing and will not stop
 
-The 37 `github-actions[bot]` commits run 2026-03-20 to 2026-08-27 and will keep
+The 38 `github-actions[bot]` commits run 2026-03-20 to 2026-08-30 and will keep
 accruing: the benchmarks workflow commits generated results and pushes to
 `main` directly. `dco.yml` triggers on `pull_request` only, so these never pass
 through it.


### PR DESCRIPTION
## What this changes

The `v0.11.0` tag failed at the first gate of `release.yml`:

```
the source tree changed between the pinned commit (db795c2) and the release
(72465dc40430) ... book/src/reference/benchmark-dashboard.html
                   book/src/reference/benchmarks.md
```

`72465dc` is `github-actions[bot]`'s `chore: update benchmark results`, pushed to main at 20:25 — after #114 merged, before the tag was cut.

**Re-tagging alone would not have been a fix.** `benchmarks.yml` triggers on push to `main` filtered to `benches/**`, `crates/**`, `Cargo.toml` and `Cargo.lock`. Every release bumps four crate versions and both lockfiles, so **merging a release PR is itself what makes that job run**, and its push lands between the merge and the tag every time. Every release touching `crates/**` — all of them — is exposed. That v0.8.0–v0.10.0 got through means those runs produced no benchmark delta, not that the window was closed.

### The guard

It guards the **push**, not the run. Benchmarks still execute on every qualifying push to main and the regression gate is untouched; only the commit to main is withheld, and only while a release is in flight.

"In flight" is read from the tree rather than guessed: **an in-tree crate version with no matching tag.** True from the moment a release-prep merge lands until the tag is pushed, false at every other moment — no schedule to keep in sync, no commit-message sniffing. Nothing is lost by skipping, since results are regenerated from scratch on each run; the first run after the tag publishes them.

It fails safe. The job's checkout is shallow and fetches no tags, so the step fetches them itself; if that fails, no tag is found and the push is skipped. Leaving main untouched is the conservative direction when the guard cannot tell.

### What was rejected, and why

Exempting the two generated files from the provenance gate's drift check. The manifest's figures are counts of **commits and authorship**, so a bot commit genuinely changes them (+1 reachable, +1 bot). Ignoring the paths would let the gate pass while the numbers were wrong by one — the exact failure mode that gate exists to prevent.

## How it was verified

Both branches of the guard exercised against this tree, with only the network fetch stubbed:

| condition | result |
|---|---|
| tag absent (release in flight) | `a release is in flight`, push skipped, exit 0 |
| tag present (post-tag) | falls through to the normal commit-and-push path |

The step passes `bash -n` with GitHub expressions stripped; the workflow parses under PyYAML and `check_block_scalars.py`.

**The gate that failed the release now passes:**

```
provenance-manifest.md is measured at c322cec, the release 1709bc4
minus only this file — all 7 headline figures match a fresh run
```

**This PR cannot re-open the window it closes.** It touches only `.github/workflows/benchmarks.yml` and `docs/provenance-manifest.md`, and neither is in the bot's trigger paths — so merging it triggers no benchmark run and no push. Main's tip after the merge is directly taggable.

Also: `prove_workflow_gates_fail.py` 20 proven / 0 unproven / exit 0; sitemap and block-scalar gates pass; DCO logic run over the range, 0 failures.

## After merging

The existing `v0.11.0` tag points at `72465dc` and its release run failed, so it has to move:

```bash
git fetch origin main --tags
git tag -d v0.11.0 && git push origin :refs/tags/v0.11.0
git checkout main && git pull
git tag -a v0.11.0 -m "Release v0.11.0"   # -a required; the UI makes a lightweight tag
git push origin v0.11.0
```

Deleting and re-pushing is low-risk here: that tag never produced a release, so nothing downstream can be pinning it.

## Checklist

- [x] **Every commit is signed off** by a human git author — DCO logic run over the range, 0 failures
- [x] SPDX header on every new file — no new files
- [x] No file exceeds 500 lines — no new files; no source changed
- [x] `cargo fmt --all` — no Rust changed
- [x] `cargo clippy` / `cargo test` / `cargo doc` — no Rust changed; CI re-runs them regardless
- [x] New code has tests — the guard's two branches are exercised above; `prove_workflow_gates_fail.py` stays 20/0
- [x] `cargo mutants` — no Rust changed, so the in-diff set is empty
- [ ] `CHANGELOG.md` not updated — this is CI plumbing and a re-measured manifest, neither user-visible in the published crates. The `[0.11.0]` entry already describes what ships.
- [ ] No ADR — a workflow guard, not an architectural decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MrW2aiMnFBwwjmwvncgg8n

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrW2aiMnFBwwjmwvncgg8n)_